### PR TITLE
Fix blog post routes for GitHub Pages 404s

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,9 +1,9 @@
 ---
 import { getCollection } from 'astro:content';
-import Layout from '../../layouts/Layout.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
-import { getReadingTime } from '../../utils/readingTime';
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { getReadingTime } from '../utils/readingTime';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');


### PR DESCRIPTION
## Summary
- move the catch-all blog post page to the top-level pages directory so posts build at the expected paths
- adjust imports accordingly after relocation

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da2372e1483218c8a928e468656c1)