### PR TITLE
Fix markdown image paths with base prefix

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import sitemap from '@astrojs/sitemap';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import yaml from '@rollup/plugin-yaml';
+import remarkPrefixImages from './src/utils/remarkPrefixImages';
 
 // https://astro.build/config
 export default defineConfig({
@@ -15,7 +16,10 @@ export default defineConfig({
     plugins: [yaml()]
   },
   markdown: {
-    remarkPlugins: [remarkMath],
+    remarkPlugins: [
+      remarkMath,
+      [remarkPrefixImages, { base: process.env.NODE_ENV === 'production' ? '/blog' : '/' }],
+    ],
     rehypePlugins: [rehypeKatex],
     shikiConfig: {
       theme: 'github-dark',

--- a/src/utils/remarkPrefixImages.ts
+++ b/src/utils/remarkPrefixImages.ts
@@ -1,0 +1,28 @@
+import type { Plugin } from 'unified';
+import type { Image } from 'mdast';
+import { visit } from 'unist-util-visit';
+
+interface Options {
+  base?: string;
+}
+
+const normalizeBase = (base: string) => {
+  if (!base.startsWith('/')) return `/${base}`;
+  return base;
+};
+
+export const remarkPrefixImages: Plugin<[Options?]> = (options = {}) => {
+  const base = normalizeBase(options.base ?? '/');
+
+  return (tree) => {
+    visit(tree, 'image', (node: Image) => {
+      if (!node.url) return;
+      if (!node.url.startsWith('/')) return;
+
+      const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+      node.url = `${trimmedBase}${node.url}`;
+    });
+  };
+};
+
+export default remarkPrefixImages;


### PR DESCRIPTION
## Summary
- add a remark plugin to prefix absolute markdown image URLs with the deployed base path
- wire the plugin into Astro markdown processing to keep images working under the GitHub Pages /blog base

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da4e664f48321bac557127c6827db)