### PR TITLE
Restore format script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "notion:sync": "tsx scripts/notion-sync.ts && tsx scripts/fix-math.ts src/content/blog/notion",
-    "format": "prettier --write \"{scripts,src}/**/*.{ts,tsx,js,jsx}\"",
+    "format": "npx --yes prettier@3.7.4 --write \"{scripts,src}/**/*.{ts,tsx,js,jsx}\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@rollup/plugin-yaml": "^4.1.2",
     "@types/node": "^25.0.3",
-    "prettier": "^3.4.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   }


### PR DESCRIPTION
## Summary
- reintroduce the format npm script
- use npx to fetch Prettier 3.7.4 on demand to avoid lockfile mismatch

## Testing
- not run (network-restricted environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dab98273c83219489d6f14569325a)