### PR TITLE
Add visitor stats and sidebar table of contents

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,46 @@
+---
+interface Heading {
+  depth: number;
+  slug: string;
+  text: string;
+}
+
+interface Props {
+  headings: Heading[];
+}
+
+const headings = Astro.props.headings
+  .filter((heading) => heading.depth <= 3)
+  .map((heading) => ({
+    ...heading,
+    indentClass: heading.depth === 3 ? 'pl-3' : '',
+  }));
+---
+
+<aside class="hidden lg:block w-64 shrink-0">
+  <div class="sticky top-24 space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4 shadow-sm dark:border-gray-800 dark:bg-gray-800/40">
+    <div>
+      <p class="text-sm font-semibold text-gray-900 dark:text-gray-100">文章目录</p>
+      <p class="text-xs text-gray-500 dark:text-gray-400">快速跳转到你关心的章节</p>
+    </div>
+    {headings.length === 0 ? (
+      <p class="text-sm text-gray-500 dark:text-gray-400">本文暂无目录。</p>
+    ) : (
+      <nav aria-label="文章目录">
+        <ol class="space-y-2 text-sm">
+          {headings.map((heading) => (
+            <li>
+              <a
+                href={`#${heading.slug}`}
+                class={`flex items-start gap-2 text-gray-700 underline-offset-2 transition hover:text-blue-600 dark:text-gray-200 dark:hover:text-blue-400 ${heading.indentClass}`}
+              >
+                <span class="mt-0.5 text-xs text-gray-400 dark:text-gray-500">#</span>
+                <span>{heading.text}</span>
+              </a>
+            </li>
+          ))}
+        </ol>
+      </nav>
+    )}
+  </div>
+</aside>

--- a/src/components/VisitorCounter.astro
+++ b/src/components/VisitorCounter.astro
@@ -1,0 +1,50 @@
+---
+interface Props {
+  storageKey?: string;
+  label?: string;
+}
+
+const storageKey = Astro.props.storageKey ?? 'blog-visitor-count';
+const label = Astro.props.label ?? '访客统计：';
+---
+
+<div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300" data-visitor-container>
+  <span aria-hidden="true">👀</span>
+  <span>{label}</span>
+  <strong data-visitor-count class="tabular-nums">--</strong>
+</div>
+
+<script is:inline data-storage-key={storageKey}>
+  (() => {
+    const scriptEl = document.currentScript;
+    const storageKey = scriptEl?.dataset.storageKey ?? 'blog-visitor-count';
+    const sessionKey = `${storageKey}-session`;
+
+    const updateText = (value) => {
+      const target = document.querySelector('[data-visitor-count]');
+      if (target) {
+        target.textContent = value;
+      }
+    };
+
+    try {
+      const hasCounted = sessionStorage.getItem(sessionKey);
+      let total = Number.parseInt(localStorage.getItem(storageKey) ?? '0', 10);
+
+      if (!Number.isFinite(total)) {
+        total = 0;
+      }
+
+      if (!hasCounted) {
+        total += 1;
+        sessionStorage.setItem(sessionKey, '1');
+        localStorage.setItem(storageKey, total.toString());
+      }
+
+      updateText(total.toLocaleString());
+    } catch (error) {
+      console.error('无法读取访客计数器存储', error);
+      updateText('N/A');
+    }
+  })();
+</script>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -4,6 +4,8 @@ import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { getReadingTime } from '../utils/readingTime';
+import TableOfContents from '../components/TableOfContents.astro';
+import VisitorCounter from '../components/VisitorCounter.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
@@ -14,40 +16,45 @@ export async function getStaticPaths() {
 }
 
 const post = Astro.props;
-const { Content } = await post.render();
+const { Content, headings } = await post.render();
 const stats = getReadingTime(post.body);
 ---
 
 <Layout title={post.data.title} description={post.data.excerpt} image={post.data.cover}>
-    <Header />
-    <main class="container mx-auto px-4 py-8 max-w-4xl">
-        <article class="prose dark:prose-invert max-w-none prose-img:rounded-xl">
-            <header class="mb-8 not-prose">
-                {post.data.cover && (
-                    <img src={post.data.cover} alt={post.data.title} class="w-full h-64 object-cover rounded-xl mb-6" />
-                )}
-                <h1 class="text-3xl md:text-4xl font-bold mb-4">{post.data.title}</h1>
-                <div class="text-gray-500 text-sm flex items-center gap-4 flex-wrap">
-                    <time class="flex items-center gap-1">
-                        <span>📅</span>
-                        {post.data.date.toLocaleDateString()}
-                    </time>
-                    <div class="flex items-center gap-1" title={`${stats.wordCount} words`}>
-                        <span>⏱️</span>
-                        {stats.text}
-                    </div>
-                    {post.data.tags.length > 0 && (
-                        <div class="flex gap-2">
-                             {post.data.tags.map(tag => (
-                                <span class="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded text-xs">#{tag}</span>
-                             ))}
-                        </div>
-                    )}
-                </div>
-            </header>
-            
-            <Content />
-        </article>
-    </main>
-    <Footer />
+  <Header />
+  <main class="container mx-auto px-4 py-8 max-w-6xl">
+    <div class="flex gap-8">
+      <TableOfContents headings={headings} />
+
+      <article class="prose dark:prose-invert max-w-none prose-img:rounded-xl flex-1">
+        <header class="mb-8 not-prose">
+          {post.data.cover && (
+            <img src={post.data.cover} alt={post.data.title} class="w-full h-64 object-cover rounded-xl mb-6" />
+          )}
+          <h1 class="text-3xl md:text-4xl font-bold mb-4">{post.data.title}</h1>
+          <div class="text-gray-500 text-sm flex items-center gap-4 flex-wrap">
+            <time class="flex items-center gap-1">
+              <span>📅</span>
+              {post.data.date.toLocaleDateString()}
+            </time>
+            <div class="flex items-center gap-1" title={`${stats.wordCount} words`}>
+              <span>⏱️</span>
+              {stats.text}
+            </div>
+            <VisitorCounter />
+            {post.data.tags.length > 0 && (
+              <div class="flex gap-2">
+                {post.data.tags.map((tag) => (
+                  <span class="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded text-xs">#{tag}</span>
+                ))}
+              </div>
+            )}
+          </div>
+        </header>
+
+        <Content />
+      </article>
+    </div>
+  </main>
+  <Footer />
 </Layout>


### PR DESCRIPTION
## Summary
- add a visitor counter widget to blog posts to track and display visit counts per session
- introduce a left-hand table of contents sidebar for quick navigation across article headings
- update post layout to accommodate the new navigation and stats elements

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db0d381f88321b50b77bb7c0a1257)