### PR TITLE
Add excerpt fallback for homepage posts

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,13 +5,38 @@ import Footer from '../components/Footer.astro';
 import { getCollection } from 'astro:content';
 import { getReadingTime } from '../utils/readingTime';
 
+const buildExcerpt = (body: string, maxLength = 160) => {
+  const clean = body
+    // Remove code fences first to avoid leaking large blocks
+    .replace(/```[\s\S]*?```/g, '')
+    // Strip inline code markers
+    .replace(/`([^`]*)`/g, '$1')
+    // Replace markdown links/images with their text
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    // Drop markdown formatting characters
+    .replace(/[#>*_~]/g, '')
+    // Collapse whitespace
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (clean.length <= maxLength) return clean;
+
+  return `${clean.slice(0, maxLength).trimEnd()}…`;
+};
+
 const posts = (await getCollection('blog'))
   .filter((post) => post.data.status === 'published')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-  .map(post => ({
+  .map(post => {
+    const explicitExcerpt = post.data.excerpt?.trim();
+
+    return {
       ...post,
-      stats: getReadingTime(post.body)
-  }));
+      stats: getReadingTime(post.body),
+      excerpt: explicitExcerpt || buildExcerpt(post.body)
+    };
+  });
 const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
 ---
 
@@ -30,7 +55,7 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
               {post.data.title}
             </h3>
             <p class="text-gray-600 dark:text-gray-400 line-clamp-2 mb-2">
-              {post.data.excerpt}
+              {post.excerpt}
             </p>
             <div class="text-sm text-gray-500 mb-2 flex items-center gap-3">
               <span class="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- generate excerpts from post bodies when no frontmatter excerpt is provided
- display the derived excerpt for each post on the homepage list

## Testing
- npm run build *(fails: astro not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db3d6b0b48321b7b2774528363bbf)