### PR TITLE
Add post search and remove excerpts

### DIFF
--- a/.astro/collections/blog.schema.json
+++ b/.astro/collections/blog.schema.json
@@ -30,9 +30,6 @@
           },
           "default": []
         },
-        "excerpt": {
-          "type": "string"
-        },
         "cover": {
           "type": "string"
         },

--- a/scripts/notion-sync.ts
+++ b/scripts/notion-sync.ts
@@ -181,7 +181,6 @@ async function sync() {
     const date =
       props.date?.date?.start || new Date().toISOString().split("T")[0];
     const tags = props.tags?.multi_select?.map((t: any) => t.name) || [];
-    const excerpt = props.excerpt?.rich_text[0]?.plain_text || "";
 
     let cover = "";
     if (page.cover) {
@@ -204,7 +203,6 @@ async function sync() {
       date,
       tags,
       status: "published",
-      excerpt,
       cover,
       notionId: pageId,
       lastEditedTime, // Important for incremental sync

--- a/src/content/blog/notion/code-is-not-only-an-implementation-but-also-a-presentation-of-a-way-of-thinking.md
+++ b/src/content/blog/notion/code-is-not-only-an-implementation-but-also-a-presentation-of-a-way-of-thinking.md
@@ -7,7 +7,6 @@ slug: >-
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 2b222dca-4210-801b-b6af-d6b37846a75e
 lastEditedTime: '2025-12-25T18:47:00.000Z'

--- a/src/content/blog/notion/context-parallel.md
+++ b/src/content/blog/notion/context-parallel.md
@@ -4,7 +4,6 @@ slug: context-parallel
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 2cd22dca-4210-81ec-89e2-f27eefb312e5
 lastEditedTime: '2025-12-25T18:13:00.000Z'

--- a/src/content/blog/notion/deepgemm-fp8-gemm.md
+++ b/src/content/blog/notion/deepgemm-fp8-gemm.md
@@ -4,7 +4,6 @@ slug: deepgemm-fp8-gemm
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 2d122dca-4210-80af-8b7b-c18d46a4f16f
 lastEditedTime: '2025-12-25T19:14:00.000Z'

--- a/src/content/blog/notion/flashattention.md
+++ b/src/content/blog/notion/flashattention.md
@@ -4,7 +4,6 @@ slug: flashattention
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 1fb22dca-4210-80cd-a96e-e32787cfd674
 lastEditedTime: '2025-12-25T17:12:00.000Z'

--- a/src/content/blog/notion/long-context.md
+++ b/src/content/blog/notion/long-context.md
@@ -4,7 +4,6 @@ slug: long-context
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 1fa22dca-4210-8019-9f72-ec95b62c0c39
 lastEditedTime: '2025-12-25T18:48:00.000Z'

--- a/src/content/blog/notion/rdma.md
+++ b/src/content/blog/notion/rdma.md
@@ -4,7 +4,6 @@ slug: rdma
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 2d022dca-4210-8002-8300-ff0fc62fb73a
 lastEditedTime: '2025-12-25T18:13:00.000Z'

--- a/src/content/blog/notion/rope.md
+++ b/src/content/blog/notion/rope.md
@@ -4,7 +4,6 @@ slug: rope
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 2d322dca-4210-8074-95ce-ec86131a7787
 lastEditedTime: '2025-12-25T16:35:00.000Z'

--- a/src/content/blog/notion/tp-sp-ep.md
+++ b/src/content/blog/notion/tp-sp-ep.md
@@ -4,7 +4,6 @@ slug: tp-sp-ep
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 2a122dca-4210-805b-ae7e-fb6b09a2e44f
 lastEditedTime: '2025-12-25T18:17:00.000Z'

--- a/src/content/blog/notion/understanding-conways-law.md
+++ b/src/content/blog/notion/understanding-conways-law.md
@@ -4,7 +4,6 @@ slug: understanding-conways-law
 date: '2025-12-25'
 tags: []
 status: published
-excerpt: ''
 cover: ''
 notionId: 2ab22dca-4210-80fe-9549-e360ee12db5e
 lastEditedTime: '2025-12-25T18:15:00.000Z'

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -5,7 +5,6 @@ const blog = defineCollection({
     title: z.string(),
     date: z.coerce.date(),
     tags: z.array(z.string()).default([]),
-    excerpt: z.string().optional(),
     cover: z.string().optional(), // Path to image in public or URL
     status: z.enum(["published", "draft"]).default("published"),
     notionId: z.string().optional(),

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -20,7 +20,7 @@ const { Content, headings } = await post.render();
 const stats = getReadingTime(post.body);
 ---
 
-<Layout title={post.data.title} description={post.data.excerpt} image={post.data.cover}>
+<Layout title={post.data.title} image={post.data.cover}>
   <Header />
   <main class="container mx-auto px-4 py-8 max-w-6xl">
     <div class="flex gap-8">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,36 +5,13 @@ import Footer from '../components/Footer.astro';
 import { getCollection } from 'astro:content';
 import { getReadingTime } from '../utils/readingTime';
 
-const buildExcerpt = (body: string, maxLength = 160) => {
-  const clean = body
-    // Remove code fences first to avoid leaking large blocks
-    .replace(/```[\s\S]*?```/g, '')
-    // Strip inline code markers
-    .replace(/`([^`]*)`/g, '$1')
-    // Replace markdown links/images with their text
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-    // Drop markdown formatting characters
-    .replace(/[#>*_~]/g, '')
-    // Collapse whitespace
-    .replace(/\s+/g, ' ')
-    .trim();
-
-  if (clean.length <= maxLength) return clean;
-
-  return `${clean.slice(0, maxLength).trimEnd()}…`;
-};
-
 const posts = (await getCollection('blog'))
   .filter((post) => post.data.status === 'published')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .map(post => {
-    const explicitExcerpt = post.data.excerpt?.trim();
-
     return {
       ...post,
       stats: getReadingTime(post.body),
-      excerpt: explicitExcerpt || buildExcerpt(post.body)
     };
   });
 const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
@@ -43,10 +20,28 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
 <Layout title="Yuanle Liu‘s Blog">
   <Header />
   <main class="container mx-auto px-4 py-8 max-w-4xl">
-    <h2 class="text-2xl font-bold mb-6">Recent Posts</h2>
-    <ul class="space-y-8">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between mb-4">
+      <h2 class="text-2xl font-bold">Recent Posts</h2>
+      <label class="relative block w-full sm:w-64">
+        <span class="sr-only">Search posts</span>
+        <span class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">🔍</span>
+        <input
+          id="post-search"
+          type="search"
+          placeholder="Search posts..."
+          class="w-full rounded-lg border border-gray-200 bg-white/50 px-10 py-2 text-sm shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-800/70 dark:focus:border-blue-400 dark:focus:ring-blue-700"
+        />
+      </label>
+    </div>
+    <p class="text-sm text-gray-500 mb-6">Found <span id="results-count">{posts.length}</span> posts</p>
+    <ul class="space-y-8" id="post-list">
       {posts.map((post) => (
-        <li class="border-b border-gray-200 dark:border-gray-800 pb-8 last:border-0">
+        <li
+          class="border-b border-gray-200 dark:border-gray-800 pb-8 last:border-0"
+          data-post
+          data-title={post.data.title.toLowerCase()}
+          data-tags={post.data.tags.join(' ').toLowerCase()}
+        >
           <a href={`${BASE}${post.slug}/`} class="group block">
             {post.data.cover && (
               <img src={post.data.cover} alt={post.data.title} class="w-full h-48 object-cover rounded-lg mb-4" />
@@ -54,9 +49,6 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
             <h3 class="text-xl font-semibold group-hover:text-blue-600 dark:group-hover:text-blue-400 mb-2">
               {post.data.title}
             </h3>
-            <p class="text-gray-600 dark:text-gray-400 line-clamp-2 mb-2">
-              {post.excerpt}
-            </p>
             <div class="text-sm text-gray-500 mb-2 flex items-center gap-3">
               <span class="flex items-center gap-1">
                 📅 {post.data.date.toLocaleDateString()}
@@ -76,6 +68,34 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
         </li>
       ))}
     </ul>
+    <p id="no-results" class="hidden text-center text-gray-500 dark:text-gray-400">No posts match your search.</p>
   </main>
   <Footer />
 </Layout>
+
+<script>
+  const searchInput = document.getElementById('post-search');
+  const postItems = Array.from(document.querySelectorAll('[data-post]'));
+  const counter = document.getElementById('results-count');
+  const emptyState = document.getElementById('no-results');
+
+  const filterPosts = (query) => {
+    const term = query.trim().toLowerCase();
+    let visibleCount = 0;
+
+    postItems.forEach((item) => {
+      const text = `${item.dataset.title} ${item.dataset.tags}`;
+      const matches = !term || text.includes(term);
+      item.classList.toggle('hidden', !matches);
+      if (matches) visibleCount += 1;
+    });
+
+    if (counter) counter.textContent = visibleCount.toString();
+    if (emptyState) emptyState.classList.toggle('hidden', visibleCount !== 0);
+  };
+
+  filterPosts(searchInput?.value || '');
+  searchInput?.addEventListener('input', (event) => {
+    filterPosts(event.target.value || '');
+  });
+</script>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -10,7 +10,7 @@ export async function GET(context) {
     items: posts.map((post) => ({
       title: post.data.title,
       pubDate: post.data.date,
-      description: post.data.excerpt,
+      description: "",
       link: `${post.slug}/`,
     })),
     customData: `<language>en-us</language>`,


### PR DESCRIPTION
## Summary
- remove article excerpts from content schema, frontmatter, and RSS metadata
- simplify post pages to rely on defaults while keeping metadata and reading-time details
- add client-side search bar on the home page to filter posts and show empty-state messaging

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbb3957e88321bca9922ef4b054db)