### PR TITLE
Enhance post search to include body content

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,6 +41,7 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
           data-post
           data-title={post.data.title.toLowerCase()}
           data-tags={post.data.tags.join(' ').toLowerCase()}
+          data-content={post.body}
         >
           <a href={`${BASE}${post.slug}/`} class="group block">
             {post.data.cover && (
@@ -84,7 +85,7 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
     let visibleCount = 0;
 
     postItems.forEach((item) => {
-      const text = `${item.dataset.title} ${item.dataset.tags}`;
+      const text = `${item.dataset.title ?? ''} ${item.dataset.tags ?? ''} ${item.dataset.content ?? ''}`.toLowerCase();
       const matches = !term || text.includes(term);
       item.classList.toggle('hidden', !matches);
       if (matches) visibleCount += 1;


### PR DESCRIPTION
## Summary
- include post body text in searchable metadata for each post item
- expand client-side search to match against titles, tags, and body content case-insensitively

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbd006c988321a6de15e64719f7d4)