### PR TITLE
Hide homepage excerpts until search is used

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -129,6 +129,11 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
     const excerptEl = item.querySelector('[data-excerpt]');
     if (!excerptEl) return;
 
+    if (!query.trim()) {
+      excerptEl.innerHTML = '';
+      return;
+    }
+
     const content = item.dataset.content ?? '';
     excerptEl.innerHTML = buildExcerpt(content, query);
   };


### PR DESCRIPTION
## Summary
- avoid rendering post excerpts on the homepage when no search query is provided
- keep excerpt generation for search results when filtering

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dc44311a08321af5de58c484a72dd)