### PR TITLE
Show visitor counts on homepage posts

### DIFF
--- a/src/components/VisitorCounter.astro
+++ b/src/components/VisitorCounter.astro
@@ -2,26 +2,35 @@
 interface Props {
   storageKey?: string;
   label?: string;
+  increment?: boolean;
 }
 
 const storageKey = Astro.props.storageKey ?? 'blog-visitor-count';
 const label = Astro.props.label ?? '访客统计：';
+const increment = Astro.props.increment ?? true;
 ---
 
-<div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300" data-visitor-container>
+<div
+  class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300"
+  data-visitor-container
+  data-storage-key={storageKey}
+>
   <span aria-hidden="true">👀</span>
   <span>{label}</span>
   <strong data-visitor-count class="tabular-nums">--</strong>
 </div>
 
-<script is:inline data-storage-key={storageKey}>
+<script is:inline data-storage-key={storageKey} data-increment={increment}>
   (() => {
     const scriptEl = document.currentScript;
     const storageKey = scriptEl?.dataset.storageKey ?? 'blog-visitor-count';
+    const increment = scriptEl?.dataset.increment !== 'false';
     const sessionKey = `${storageKey}-session`;
-
+    const container = scriptEl?.parentElement?.querySelector(
+      `[data-visitor-container][data-storage-key="${storageKey}"]`,
+    );
     const updateText = (value) => {
-      const target = document.querySelector('[data-visitor-count]');
+      const target = container?.querySelector('[data-visitor-count]');
       if (target) {
         target.textContent = value;
       }
@@ -35,7 +44,7 @@ const label = Astro.props.label ?? '访客统计：';
         total = 0;
       }
 
-      if (!hasCounted) {
+      if (increment && !hasCounted) {
         total += 1;
         sessionStorage.setItem(sessionKey, '1');
         localStorage.setItem(storageKey, total.toString());

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -18,6 +18,7 @@ export async function getStaticPaths() {
 const post = Astro.props;
 const { Content, headings } = await post.render();
 const stats = getReadingTime(post.body);
+const visitorStorageKey = `post-${post.slug}-visitors`;
 ---
 
 <Layout title={post.data.title} image={post.data.cover}>
@@ -41,7 +42,7 @@ const stats = getReadingTime(post.body);
               <span>⏱️</span>
               {stats.text}
             </div>
-            <VisitorCounter />
+            <VisitorCounter storageKey={visitorStorageKey} />
             {post.data.tags.length > 0 && (
               <div class="flex gap-2">
                 {post.data.tags.map((tag) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,17 +4,19 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { getCollection } from 'astro:content';
 import { getReadingTime } from '../utils/readingTime';
+import VisitorCounter from '../components/VisitorCounter.astro';
 
 const posts = (await getCollection('blog'))
   .filter((post) => post.data.status === 'published')
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-  .map(post => {
-    return {
-      ...post,
-      stats: getReadingTime(post.body),
-    };
-  });
-const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
+  .map((post) => ({
+    ...post,
+    stats: getReadingTime(post.body),
+    visitorStorageKey: `post-${post.slug}-visitors`,
+  }));
+const BASE = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
 ---
 
 <Layout title="Yuanle Liu‘s Blog">
@@ -43,9 +45,10 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
               <span class="flex items-center gap-1" title={`${post.stats.wordCount} words`}>
                 ⏱️ {post.stats.text}
               </span>
+              <VisitorCounter storageKey={post.visitorStorageKey} increment={false} />
               {post.data.tags.length > 0 && (
                 <span class="ml-auto flex gap-2">
-                  {post.data.tags.map(t => (
+                  {post.data.tags.map((t) => (
                     <span class="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded text-xs">#{t}</span>
                   ))}
                 </span>


### PR DESCRIPTION
## Summary
- add per-post visitor counters to the homepage listing
- scope visitor counter scripts and allow optional increments for list usage
- align post detail pages to use shared visitor counter keys
- format homepage visitor counter listing code

## Testing
- npx --yes prettier@3.7.4 --write "src/**/*.{astro,ts,tsx,js,jsx}" *(fails: registry access returns 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd7dd0a5c8321be38eb0f0adcd2e9)