### PR TITLE
Improve reading time word counting accuracy

### DIFF
--- a/src/utils/readingTime.ts
+++ b/src/utils/readingTime.ts
@@ -1,12 +1,14 @@
 export function getReadingTime(content: string) {
   const wordsPerMinute = 200;
-  // Strip HTML tags and newlines, then split by whitespace
-  const cleanContent = content
-    .replace(/<[^>]*>/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-  const wordCount = cleanContent.split(" ").length;
-  const readingTime = Math.ceil(wordCount / wordsPerMinute);
+  // Remove HTML tags but keep spacing so that inline text stays separable
+  const cleanContent = content.replace(/<[^>]*>/g, " ");
+
+  // Count tokens in a way that works for Chinese, English, numbers, and code:
+  // - Each Han character counts as 1
+  // - Continuous runs of ASCII letters/digits (including common apostrophes) count as 1
+  const tokens = cleanContent.match(/\p{Script=Han}|[A-Za-z0-9]+(?:'[A-Za-z0-9]+)?/gu);
+  const wordCount = tokens ? tokens.length : 0;
+  const readingTime = wordCount > 0 ? Math.max(1, Math.ceil(wordCount / wordsPerMinute)) : 0;
 
   return {
     wordCount,


### PR DESCRIPTION
## Summary
- preserve spacing while stripping HTML to retain inline content
- count tokens with Unicode-aware regex to include Chinese, English, numbers, and code
- keep a minimum one-minute reading time when content is present

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dffca15248321a740957f07811f31)