### PR TITLE
Enhance markdown rendering and add discovery features

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Sync Notion content
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+        run: npm run notion:sync
+
+      - name: Generate search index
+        run: npx tsx scripts/generate-search-index.ts
+
       - name: Build with Astro
         run: npm run build
       

--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -32,6 +32,9 @@ jobs:
           NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
         run: npm run notion:sync
 
+      - name: Generate search index
+        run: npx tsx scripts/generate-search-index.ts
+
       - name: Commit and Push Changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,9 +2,14 @@ import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
 import sitemap from '@astrojs/sitemap';
 import remarkMath from 'remark-math';
+import remarkGfm from 'remark-gfm';
 import rehypeKatex from 'rehype-katex';
 import yaml from '@rollup/plugin-yaml';
 import remarkPrefixImages from './src/utils/remarkPrefixImages';
+import remarkNotionCompat from './src/utils/remarkNotionCompat';
+import rehypeCodeEnhance from './src/utils/rehypeCodeEnhance';
+import rehypeHeadingLinks from './src/utils/rehypeHeadingLinks';
+import rehypeExternalLinks from './src/utils/rehypeExternalLinks';
 
 // https://astro.build/config
 export default defineConfig({
@@ -18,9 +23,16 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [
       remarkMath,
+      remarkGfm,
+      remarkNotionCompat,
       [remarkPrefixImages, { base: process.env.NODE_ENV === 'production' ? '/blog' : '/' }],
     ],
-    rehypePlugins: [rehypeKatex],
+    rehypePlugins: [
+      rehypeKatex,
+      rehypeHeadingLinks,
+      [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'noreferrer'] }],
+      rehypeCodeEnhance,
+    ],
     shikiConfig: {
       theme: 'github-dark',
       wrap: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,11 @@
         "katex": "^0.16.27",
         "notion-to-md": "^3.1.9",
         "rehype-katex": "^7.0.1",
+        "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
         "slugify": "^1.6.6",
-        "tailwindcss": "^3.4.17"
+        "tailwindcss": "^3.4.17",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@rollup/plugin-yaml": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "notion:sync": "tsx scripts/notion-sync.ts && tsx scripts/fix-math.ts src/content/blog/notion",
+    "search:index": "tsx scripts/generate-search-index.ts",
     "format": "npx --yes prettier@3.7.4 --write \"{scripts,src}/**/*.{ts,tsx,js,jsx}\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -31,8 +32,10 @@
     "notion-to-md": "^3.1.9",
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
+    "remark-gfm": "^4.0.0",
     "slugify": "^1.6.6",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-yaml": "^4.1.2",

--- a/public/search-index.json
+++ b/public/search-index.json
@@ -1,0 +1,65 @@
+[
+  {
+    "title": "Code is not only an implementation, but also a presentation of a way of thinking",
+    "slug": "code-is-not-only-an-implementation-but-also-a-presentation-of-a-way-of-thinking",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " <u>_**在日常开发中，我们往往把重点放在“把功能实现出来”。但一个成熟工程师的代码，并不仅仅是代码本身，而是其思维方式、问题拆解能力、沟通意识与系统理解的外化形式。**_</u> ## 一、系统思维：看到代码之外的系统 优秀工程师写代码时并不是只盯着一个函数或一个类，而是思考： 1. 这个模块在整个系统中承担什么角色？ 2. 它如何与其他模块协作？ 3. 当模块演化时，哪些边界会受到影响？ 4. 未来扩展时，能否复用当前设计？可能的瓶颈是什么？ <u>_具备系统视角的代码更加稳健，也更容易在团队内被复用，不会"
+  },
+  {
+    "title": "Context Parallel 技术解析",
+    "slug": "context-parallel",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " --- ## 学习链接 - [[并行训练]Context Parallelism的原理与代码浅析 - 知乎](https://zhuanlan.zhihu.com/p/698447429?share_code=WwUutv3avJIE&utm_psn=1983881801186444490) - [ring attention + flash attention：超长上下文之路 - 知乎](https://zhuanlan.zhihu.com/p/683714620) - [大模型训练之序列并行双雄：DeepSp"
+  },
+  {
+    "title": "DeepGEMM 学习指南：面向初学者的 FP8 GEMM 库解析",
+    "slug": "deepgemm-fp8-gemm",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " --- ## 优质博客 - CUTLASS & GPU CUDA 编程解析 [https://research.colfax-intl.com/blog/](https://research.colfax-intl.com/blog/) ## 一、总体设计与原理 ### 1.1 DeepGEMM 是什么？ DeepGEMM 是由 DeepSeek 团队开源的一个专注于 FP8 矩阵乘法（GEMM）的高效库。它旨在为深度学习中的矩阵乘法提供**高效**且**简洁**的实现，同时支持常规密集矩阵乘法和混合专家模型（M"
+  },
+  {
+    "title": "FlashAttention 原理与实现",
+    "slug": "flashattention",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " --- ## 学习链接 - [图解大模型计算加速系列：FlashAttention V1，从硬件到计算逻辑 - 知乎](https://zhuanlan.zhihu.com/p/669926191) - [图解大模型计算加速系列：FlashAttention V2，从原理到并行计算 - 知乎](https://zhuanlan.zhihu.com/p/691067658) - [\\[Attention优化\\]\\[2w字\\]📚原理篇: 从Online-Softmax到FlashAttention V1/V2/V3"
+  },
+  {
+    "title": "Long Context 推理优化技术梳理",
+    "slug": "long-context",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " --- ## 优质博客 - [[LLM性能优化] 聊聊长文本推理性能优化方向 - 知乎](https://zhuanlan.zhihu.com/p/698308542) - [Deploying DeepSeek with PD Disaggregation and Large-Scale Expert Parallelism on 96 H100 GPUs | LMSYS Org](https://lmsys.org/blog/2025-05-05-large-scale-ep/) - [Implement F"
+  },
+  {
+    "title": "RDMA 在大模型推理框架中的应用",
+    "slug": "rdma",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " ## [极简] RDMA 在大模型推理框架中的应用 --- 在现代大规模 LLM 推理系统中，**多 GPU / 多节点推理已成为必然**。无论是模型本身的体积（70B/405B/1T+）还是长上下文（128k~1M tokens），都远超单节点能力。 为保证吞吐和延迟，推理框架需要极为高效的跨 GPU / 跨节点通信，而 **RDMA（Remote Direct Memory Access）** 由于具备： - **GPU → GPU 的零拷贝（GPUDirect RDMA）** - **绕过 CPU 和内核协"
+  },
+  {
+    "title": "RoPE 究竟是怎么计算的",
+    "slug": "rope",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " --- ## 一、RoPE 到底改了什么？ Attention 里我们原来用： - $Q, K, V$ 计算 $\\text{Attn}(Q, K, V)$ RoPE 做的是把 **Q/K 先旋转**： - $Q' = \\text{RoPE}(Q, \\text{pos})$ - $K' = \\text{RoPE}(K, \\text{pos})$ - 然后用 $Q', K', V$ 做 attention --- ## 二、数学形式：2D 旋转（每两维一组） 对每个 position $p$，对某一对维度 $(u,v"
+  },
+  {
+    "title": "一种 TP-SP-EP 混合并行策略",
+    "slug": "tp-sp-ep",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " --- ## 一、两种混合并行图示 ![非完整图示，不含后续 EP 并行 MoE 层。](/images/notion/2a122dca-4210-805b-ae7e-fb6b09a2e44f/2b222dca-4210-80d9-98fb-cf78ef53eb91.jpeg) --- ## 二、并行原理解析 ### 2.1 前提：`qkv_inear` (列切) 两种方案都始于一个**列并行 (Column-Parallel)** 的 `qkv_inear` 层。 - 我们有 $N$ 个 GPU。 - 输入 $"
+  },
+  {
+    "title": "Understanding Conway’s Law（康威定律）",
+    "slug": "understanding-conways-law",
+    "date": "2025-12-25",
+    "tags": [],
+    "excerpt": " <u>_**康威定律（Conway’s Law）：设计系统的组织，其产生的系统设计，必然反映该组织的沟通结构。**_</u> 软件代码结构是部门组织形态的体现，分支管理则是这种组织形态在时间维度上的投影。组织如何沟通、如何划分责任、如何整合成果，都会直接在代码仓库的结构与分支策略中体现。优秀的组织会通过良好的分支策略促进协作，糟糕的分支策略则会放大组织壁垒。 ### 一、软件结构与组织形态的镜像关系 软件代码结构是部门组织形态的体现。换句话说，组织如何划分团队、沟通与协作，最终都会被固化在系统架构与代码模块中。 "
+  }
+]

--- a/scripts/generate-search-index.ts
+++ b/scripts/generate-search-index.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONTENT_DIR = path.resolve(__dirname, '../src/content/blog');
+const OUTPUT = path.resolve(__dirname, '../public/search-index.json');
+
+interface SearchEntry {
+  title: string;
+  slug: string;
+  date: string;
+  tags: string[];
+  excerpt: string;
+}
+
+function readPosts(dir: string): SearchEntry[] {
+  const entries: SearchEntry[] = [];
+  for (const file of fs.readdirSync(dir)) {
+    const full = path.join(dir, file);
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) {
+      entries.push(...readPosts(full));
+      continue;
+    }
+    if (!file.endsWith('.md') && !file.endsWith('.mdx')) continue;
+    const raw = fs.readFileSync(full, 'utf-8');
+    const { data, content } = matter(raw);
+    if (data.status && data.status !== 'published') continue;
+    const slug = data.slug || path.basename(file, path.extname(file));
+    const excerpt = content.replace(/\n+/g, ' ').slice(0, 260);
+    entries.push({
+      title: data.title || slug,
+      slug,
+      date: data.date || new Date().toISOString(),
+      tags: data.tags || [],
+      excerpt,
+    });
+  }
+  return entries.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
+function main() {
+  const posts = readPosts(CONTENT_DIR);
+  fs.mkdirSync(path.dirname(OUTPUT), { recursive: true });
+  fs.writeFileSync(OUTPUT, JSON.stringify(posts, null, 2));
+  console.log(`Saved ${posts.length} entries to ${OUTPUT}`);
+}
+
+main();

--- a/src/components/CodeBlockCopy.astro
+++ b/src/components/CodeBlockCopy.astro
@@ -1,0 +1,23 @@
+<script>
+  const copy = async (button: HTMLButtonElement) => {
+    const pre = button.closest('pre');
+    const code = pre?.querySelector('code');
+    if (!code) return;
+    const text = (code.textContent || '').replace(/\n+$/, '\n');
+    await navigator.clipboard.writeText(text);
+    button.textContent = 'Copied';
+    setTimeout(() => (button.textContent = 'Copy'), 1500);
+  };
+
+  const attach = () => {
+    document.querySelectorAll<HTMLButtonElement>('button.code-copy').forEach((btn) => {
+      if (btn.dataset.bound) return;
+      btn.dataset.bound = 'true';
+      btn.addEventListener('click', () => copy(btn));
+    });
+  };
+
+  const observer = new MutationObserver(attach);
+  observer.observe(document.body, { subtree: true, childList: true });
+  attach();
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,8 +6,11 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
         <a href={BASE} class="text-xl font-bold hover:text-blue-600 dark:hover:text-blue-400">Yuanle Liu‘s Blog</a>
         <nav class="flex items-center gap-3">
             <a href={BASE} class="hover:underline">Home</a>
+            <a href={`${BASE}tags/`} class="hover:underline">Tags</a>
+            <a href={`${BASE}archive/`} class="hover:underline">Archive</a>
             <a href={`${BASE}about/`} class="hover:underline">About</a>
             <a href={`${BASE}rss.xml`} class="hover:underline">RSS</a>
+            <button data-search-open class="px-2 py-1 text-sm rounded bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700">Search ⌘K</button>
             <button id="theme-toggle" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800" aria-label="Toggle theme">
                 🌙/☀️
             </button>

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,0 +1,39 @@
+---
+import { getReadingTime } from '../utils/readingTime';
+import TagList from './TagList.astro';
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+  posts: CollectionEntry<'blog'>[];
+}
+
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
+const { posts } = Astro.props;
+const enriched = posts.map((post) => ({ ...post, stats: getReadingTime(post.body) }));
+---
+<ul class="space-y-8" id="post-list">
+  {enriched.map((post) => (
+    <li class="border-b border-gray-200 dark:border-gray-800 pb-8 last:border-0">
+      <a href={`${BASE}${post.slug}/`} class="group block">
+        {post.data.cover && (
+          <img src={post.data.cover} alt={post.data.title} class="w-full h-48 object-cover rounded-lg mb-4" />
+        )}
+        <h3 class="text-xl font-semibold group-hover:text-blue-600 dark:group-hover:text-blue-400 mb-2">
+          {post.data.title}
+        </h3>
+        <div class="text-sm text-gray-500 mb-2 flex items-center gap-3 flex-wrap">
+          <span class="flex items-center gap-1">📅 {post.data.date.toLocaleDateString()}</span>
+          <span class="flex items-center gap-1">✍️ {post.stats.wordCount} 字</span>
+          <span class="flex items-center gap-1" title={`${post.stats.wordCount} words`}>
+            ⏱️ {post.stats.text}
+          </span>
+        </div>
+      </a>
+      {post.data.tags.length > 0 && (
+        <div class="mt-2">
+          <TagList tags={post.data.tags} />
+        </div>
+      )}
+    </li>
+  ))}
+</ul>

--- a/src/components/PrevNext.astro
+++ b/src/components/PrevNext.astro
@@ -1,0 +1,30 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+  prev?: CollectionEntry<'blog'>;
+  next?: CollectionEntry<'blog'>;
+}
+
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
+const { prev, next } = Astro.props;
+---
+<div class="grid md:grid-cols-2 gap-4 mt-10">
+  {prev ? (
+    <a href={`${BASE}${prev.slug}/`} class="block p-4 rounded-lg border border-gray-200 dark:border-gray-800 hover:border-blue-500">
+      <div class="text-xs uppercase text-gray-500">Previous</div>
+      <div class="font-semibold">{prev.data.title}</div>
+    </a>
+  ) : (
+    <div />
+  )}
+
+  {next ? (
+    <a href={`${BASE}${next.slug}/`} class="block p-4 rounded-lg border border-gray-200 dark:border-gray-800 hover:border-blue-500 text-right">
+      <div class="text-xs uppercase text-gray-500">Next</div>
+      <div class="font-semibold">{next.data.title}</div>
+    </a>
+  ) : (
+    <div />
+  )}
+</div>

--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,29 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+  posts: CollectionEntry<'blog'>[];
+}
+
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
+const { posts } = Astro.props;
+---
+{posts.length > 0 && (
+  <div class="mt-10 border-t border-gray-200 dark:border-gray-800 pt-6">
+    <h3 class="text-lg font-semibold mb-4">Related posts</h3>
+    <div class="grid md:grid-cols-2 gap-4">
+      {posts.map((post) => (
+        <a
+          href={`${BASE}${post.slug}/`}
+          class="block p-4 rounded-lg border border-gray-200 dark:border-gray-800 hover:border-blue-500 hover:-translate-y-0.5 transition"
+        >
+          <div class="text-xs text-gray-500 mb-1">{post.data.date.toLocaleDateString()}</div>
+          <div class="font-semibold">{post.data.title}</div>
+          {post.data.tags.length > 0 && (
+            <div class="text-xs text-gray-500 mt-1">#{post.data.tags.join(', #')}</div>
+          )}
+        </a>
+      ))}
+    </div>
+  </div>
+)}

--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -1,0 +1,98 @@
+---
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
+---
+<div id="search-modal" class="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 hidden">
+  <div class="max-w-3xl mx-auto mt-16 bg-white dark:bg-gray-900 rounded-xl shadow-lg p-6 border border-gray-200 dark:border-gray-800">
+    <div class="flex items-center gap-3 mb-4">
+      <input
+        id="search-input"
+        type="search"
+        placeholder="Search title, tags, summary..."
+        class="w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      />
+      <button id="search-close" class="text-sm px-3 py-2 rounded-lg bg-gray-100 dark:bg-gray-800">Close</button>
+    </div>
+    <div id="search-results" class="space-y-3 max-h-96 overflow-y-auto"></div>
+  </div>
+</div>
+
+<script>
+  const BASE_URL = BASE;
+  const modal = document.getElementById('search-modal')!;
+  const input = document.getElementById('search-input') as HTMLInputElement | null;
+  const closeBtn = document.getElementById('search-close');
+  let cache: any[] | null = null;
+
+  const toggle = (open: boolean) => {
+    if (!modal) return;
+    modal.classList.toggle('hidden', !open);
+    document.body.classList.toggle('overflow-hidden', open);
+    if (open) {
+      input?.focus();
+    } else {
+      input!.value = '';
+      render([]);
+    }
+  };
+
+  const render = (items: any[]) => {
+    const container = document.getElementById('search-results');
+    if (!container) return;
+    container.innerHTML = '';
+    if (items.length === 0) {
+      container.innerHTML = '<p class="text-sm text-gray-500">No results</p>';
+      return;
+    }
+    const base = BASE_URL.endsWith('/') ? BASE_URL : BASE_URL + '/';
+    items.forEach((item) => {
+      const el = document.createElement('a');
+      el.href = `${base}${item.slug}/`;
+      el.className = 'block p-3 rounded-lg border border-gray-200 dark:border-gray-800 hover:border-blue-500 hover:bg-blue-50/40 dark:hover:bg-gray-800';
+      el.innerHTML = `<div class="text-sm text-gray-500">${new Date(item.date).toLocaleDateString()} · ${item.tags.join(', ')}</div><div class="font-semibold">${item.title}</div><div class="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">${item.excerpt}</div>`;
+      container.appendChild(el);
+    });
+  };
+
+  const search = (term: string) => {
+    if (!cache) return [];
+    const needle = term.toLowerCase();
+    return cache.filter((item) =>
+      `${item.title} ${item.excerpt} ${item.tags.join(' ')}`.toLowerCase().includes(needle)
+    ).slice(0, 20);
+  };
+
+  const load = async () => {
+    if (cache) return cache;
+    const resp = await fetch(`${BASE_URL}search-index.json`);
+    cache = await resp.json();
+    return cache;
+  };
+
+  const handleOpen = () => toggle(true);
+  const handleClose = () => toggle(false);
+
+  document.addEventListener('keydown', (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      handleOpen();
+    }
+    if (e.key === 'Escape') handleClose();
+  });
+
+  document.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('[data-search-open]')) {
+      e.preventDefault();
+      handleOpen();
+    }
+    if (target.id === 'search-modal') handleClose();
+  });
+
+  closeBtn?.addEventListener('click', handleClose);
+
+  input?.addEventListener('input', async (e) => {
+    const value = (e.target as HTMLInputElement).value.trim();
+    await load();
+    render(value ? search(value) : []);
+  });
+</script>

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  tags: string[];
+}
+
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
+const { tags } = Astro.props;
+---
+<div class="flex flex-wrap gap-2">
+  {tags.map((tag) => (
+    <a
+      href={`${BASE}tags/${encodeURIComponent(tag)}/`}
+      class="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-xs hover:bg-blue-100 dark:hover:bg-gray-700"
+    >
+      #{tag}
+    </a>
+  ))}
+</div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,52 +1,114 @@
 ---
 import 'katex/dist/katex.min.css';
+import CodeBlockCopy from '../components/CodeBlockCopy.astro';
+import SearchModal from '../components/SearchModal.astro';
 
 interface Props {
-	title: string;
-    description?: string;
-    image?: string;
+  title: string;
+  description?: string;
+  image?: string;
 }
 
 const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
+const url = new URL(Astro.url.pathname, new URL(BASE, Astro.site ?? 'http://localhost/')).toString();
 const { title, description = "A minimal Astro blog", image = `${BASE}placeholder-social.jpg` } = Astro.props;
 ---
 
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="description" content={description} />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href={`${BASE}favicon.svg`} />
-		<meta name="generator" content={Astro.generator} />
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={description} />
-        <meta property="og:image" content={image} />
-		<title>{title}</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content={description} />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href={`${BASE}favicon.svg`} />
+    <meta name="generator" content={Astro.generator} />
+    <link rel="canonical" href={url} />
+    <link rel="alternate" type="application/rss+xml" title="RSS" href={`${BASE}rss.xml`} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={image} />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content={url} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={image} />
+    <title>{title}</title>
         
-        <!-- Dark Mode Script -->
-        <script is:inline>
-            const theme = (() => {
-                if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-                    return localStorage.getItem('theme');
-                }
-                if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                    return 'dark';
-                }
-                return 'light';
-            })();
-        
-            if (theme === 'dark') {
-                document.documentElement.classList.add('dark');
-            } else {
-                document.documentElement.classList.remove('dark');
-            }
-        </script>
-        
-        <!-- Math Support -->
-        <!-- CSS imported in frontmatter -->
-	</head>
-	<body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-300 min-h-screen flex flex-col">
-		<slot />
-	</body>
+    <!-- Dark Mode Script -->
+    <script is:inline>
+      const theme = (() => {
+        if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+          return localStorage.getItem('theme');
+        }
+        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+          return 'dark';
+        }
+        return 'light';
+      })();
+
+      if (theme === 'dark') {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+    </script>
+
+    <style>
+      :root {
+        scroll-behavior: smooth;
+      }
+      pre.code-block {
+        position: relative;
+        overflow-x: auto;
+        border-radius: 0.75rem;
+        padding-top: 2.75rem;
+      }
+      .code-copy {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.75rem;
+        padding: 0.25rem 0.65rem;
+        border-radius: 9999px;
+        font-size: 0.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        background: rgba(0, 0, 0, 0.35);
+        color: white;
+        cursor: pointer;
+        transition: opacity 0.2s ease, transform 0.15s ease;
+      }
+      .code-copy:hover {
+        opacity: 0.9;
+        transform: translateY(-1px);
+      }
+      .code-lang {
+        position: absolute;
+        top: 0.6rem;
+        left: 1rem;
+        text-transform: uppercase;
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+        color: #cbd5e1;
+      }
+      .heading-anchor {
+        margin-left: 0.35rem;
+        opacity: 0;
+        text-decoration: none;
+        transition: opacity 0.2s ease;
+      }
+      h1:hover .heading-anchor,
+      h2:hover .heading-anchor,
+      h3:hover .heading-anchor,
+      h4:hover .heading-anchor,
+      h5:hover .heading-anchor,
+      h6:hover .heading-anchor {
+        opacity: 0.65;
+      }
+    </style>
+  </head>
+  <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-300 min-h-screen flex flex-col">
+    <SearchModal />
+    <slot />
+    <CodeBlockCopy />
+  </body>
 </html>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,22 +1,27 @@
 ---
-import { getCollection } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { getReadingTime } from '../utils/readingTime';
 import TableOfContents from '../components/TableOfContents.astro';
+import TagList from '../components/TagList.astro';
+import PrevNext from '../components/PrevNext.astro';
+import RelatedPosts from '../components/RelatedPosts.astro';
+import { findPrevNext, findRelated, getPublishedPosts } from '../utils/posts';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
+  const posts = await getPublishedPosts();
   return posts.map((post) => ({
     params: { slug: post.slug },
-    props: post,
+    props: { post, all: posts },
   }));
 }
 
-const post = Astro.props;
+const { post, all } = Astro.props;
 const { Content, headings } = await post.render();
 const stats = getReadingTime(post.body);
+const { prev, next } = findPrevNext(all, post.slug);
+const related = findRelated(all, post);
 ---
 
 <Layout title={post.data.title} image={post.data.cover}>
@@ -44,17 +49,14 @@ const stats = getReadingTime(post.body);
               <span>⏱️</span>
               {stats.text}
             </div>
-            {post.data.tags.length > 0 && (
-              <div class="flex gap-2">
-                {post.data.tags.map((tag) => (
-                  <span class="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded text-xs">#{tag}</span>
-                ))}
-              </div>
-            )}
+            {post.data.tags.length > 0 && <TagList tags={post.data.tags} />}
           </div>
         </header>
 
         <Content />
+
+        <PrevNext prev={prev} next={next} />
+        <RelatedPosts posts={related} />
       </article>
     </div>
   </main>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,0 +1,36 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { getPublishedPosts, groupByYearMonth } from '../utils/posts';
+import TagList from '../components/TagList.astro';
+
+const posts = await getPublishedPosts();
+const groups = groupByYearMonth(posts);
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : `${import.meta.env.BASE_URL}/`;
+---
+<Layout title="Archive | Yuanle Liu‘s Blog">
+  <Header />
+  <main class="container mx-auto px-4 py-8 max-w-4xl">
+    <h1 class="text-3xl font-bold mb-6">Archive</h1>
+    <div class="space-y-6">
+      {groups.map((group) => (
+        <section class="border border-gray-200 dark:border-gray-800 rounded-xl p-4" aria-label={group.key}>
+          <h2 class="text-xl font-semibold mb-3">{group.key}</h2>
+          <ul class="space-y-3">
+            {group.posts.map((post) => (
+              <li class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <a href={`${BASE}${post.slug}/`} class="font-medium hover:text-blue-600">{post.data.title}</a>
+                <div class="flex items-center gap-3 text-sm text-gray-500">
+                  <span>{post.data.date.toLocaleDateString()}</span>
+                  {post.data.tags.length > 0 && <TagList tags={post.data.tags} />}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,19 +2,15 @@
 import Layout from '../layouts/Layout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
-import { getCollection } from 'astro:content';
-import { getReadingTime } from '../utils/readingTime';
+import PostList from '../components/PostList.astro';
+import { getPublishedPosts } from '../utils/posts';
 
-const posts = (await getCollection('blog'))
-  .filter((post) => post.data.status === 'published')
-  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-  .map((post) => ({
-    ...post,
-    stats: getReadingTime(post.body),
-  }));
-const BASE = import.meta.env.BASE_URL.endsWith('/')
-  ? import.meta.env.BASE_URL
-  : `${import.meta.env.BASE_URL}/`;
+const posts = await getPublishedPosts();
+const PAGE_SIZE = 5;
+const currentPage = 1;
+const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
+const pagePosts = posts.slice(0, PAGE_SIZE);
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : `${import.meta.env.BASE_URL}/`;
 ---
 
 <Layout title="Yuanle Liu‘s Blog">
@@ -24,40 +20,18 @@ const BASE = import.meta.env.BASE_URL.endsWith('/')
       <h2 class="text-2xl font-bold">Recent Posts</h2>
       <p class="text-sm text-gray-500">{posts.length} published posts</p>
     </div>
-    <ul class="space-y-8" id="post-list">
-      {posts.map((post) => (
-        <li
-          class="border-b border-gray-200 dark:border-gray-800 pb-8 last:border-0"
-        >
-          <a href={`${BASE}${post.slug}/`} class="group block">
-            {post.data.cover && (
-              <img src={post.data.cover} alt={post.data.title} class="w-full h-48 object-cover rounded-lg mb-4" />
-            )}
-            <h3 class="text-xl font-semibold group-hover:text-blue-600 dark:group-hover:text-blue-400 mb-2">
-              {post.data.title}
-            </h3>
-            <div class="text-sm text-gray-500 mb-2 flex items-center gap-3">
-              <span class="flex items-center gap-1">
-                📅 {post.data.date.toLocaleDateString()}
-              </span>
-              <span class="flex items-center gap-1">
-                ✍️ {post.stats.wordCount} 字
-              </span>
-              <span class="flex items-center gap-1" title={`${post.stats.wordCount} words`}>
-                ⏱️ {post.stats.text}
-              </span>
-              {post.data.tags.length > 0 && (
-                <span class="ml-auto flex gap-2">
-                  {post.data.tags.map((t) => (
-                    <span class="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded text-xs">#{t}</span>
-                  ))}
-                </span>
-              )}
-            </div>
-          </a>
-        </li>
-      ))}
-    </ul>
+    <PostList posts={pagePosts} />
+
+    {totalPages > 1 && (
+      <div class="flex justify-between items-center mt-10 text-sm">
+        <div>Page {currentPage} / {totalPages}</div>
+        <div class="flex gap-2">
+          {currentPage < totalPages && (
+            <a href={`${BASE}page/${currentPage + 1}/`} class="px-3 py-2 rounded bg-gray-100 dark:bg-gray-800">Older →</a>
+          )}
+        </div>
+      </div>
+    )}
   </main>
   <Footer />
 </Layout>

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -1,0 +1,45 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import PostList from '../../components/PostList.astro';
+import { getPublishedPosts } from '../../utils/posts';
+
+export async function getStaticPaths() {
+  const PAGE_SIZE = 5;
+  const posts = await getPublishedPosts();
+  const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
+  return Array.from({ length: totalPages }, (_, i) => {
+    const page = i + 1;
+    const slice = posts.slice(i * PAGE_SIZE, (i + 1) * PAGE_SIZE);
+    return { params: { page: String(page) }, props: { slice, page, totalPages } };
+  });
+}
+
+const { slice, page, totalPages } = Astro.props;
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : `${import.meta.env.BASE_URL}/`;
+---
+<Layout title={`Page ${page} | Yuanle Liu‘s Blog`}>
+  <Header />
+  <main class="container mx-auto px-4 py-8 max-w-4xl">
+    <div class="flex flex-col gap-2 mb-6">
+      <h2 class="text-2xl font-bold">Posts</h2>
+      <p class="text-sm text-gray-500">Page {page} / {totalPages}</p>
+    </div>
+    <PostList posts={slice} />
+
+    <div class="flex justify-between items-center mt-10 text-sm">
+      {page > 1 ? (
+        <a href={page === 2 ? `${BASE}` : `${BASE}page/${page - 1}/`} class="px-3 py-2 rounded bg-gray-100 dark:bg-gray-800">← Newer</a>
+      ) : (
+        <span />
+      )}
+      {page < totalPages ? (
+        <a href={`${BASE}page/${page + 1}/`} class="px-3 py-2 rounded bg-gray-100 dark:bg-gray-800">Older →</a>
+      ) : (
+        <span />
+      )}
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -2,15 +2,18 @@ import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 
 export async function GET(context) {
-  const posts = await getCollection("blog");
+  const posts = (await getCollection("blog"))
+    .filter((post) => post.data.status === "published")
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
   return rss({
-    title: "My Astro Blog",
-    description: "A minimal blog built with Astro and Notion",
+    title: "Yuanle Liu‘s Blog",
+    description: "Engineering notes from Astro + Notion",
     site: context.site,
     items: posts.map((post) => ({
       title: post.data.title,
       pubDate: post.data.date,
-      description: "",
+      description: post.body.slice(0, 180),
+      categories: post.data.tags,
       link: `${post.slug}/`,
     })),
     customData: `<language>en-us</language>`,

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,24 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import PostList from '../../components/PostList.astro';
+import { getPublishedPosts } from '../../utils/posts';
+
+export async function getStaticPaths() {
+  const posts = await getPublishedPosts();
+  const tagSet = new Set(posts.flatMap((p) => p.data.tags));
+  return Array.from(tagSet).map((tag) => ({ params: { tag }, props: { tag, posts } }));
+}
+
+const { tag, posts } = Astro.props;
+const filtered = posts.filter((p) => p.data.tags.includes(tag)).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+---
+<Layout title={`#${tag} | Yuanle Liu‘s Blog`}>
+  <Header />
+  <main class="container mx-auto px-4 py-8 max-w-4xl">
+    <h1 class="text-3xl font-bold mb-6">Tag: #{tag}</h1>
+    <PostList posts={filtered} />
+  </main>
+  <Footer />
+</Layout>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,28 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { collectTags, getPublishedPosts } from '../../utils/posts';
+
+const posts = await getPublishedPosts();
+const tags = collectTags(posts);
+const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : `${import.meta.env.BASE_URL}/`;
+---
+<Layout title="Tags | Yuanle Liu‘s Blog">
+  <Header />
+  <main class="container mx-auto px-4 py-8 max-w-4xl">
+    <h1 class="text-3xl font-bold mb-6">Tags</h1>
+    <div class="grid sm:grid-cols-2 gap-4">
+      {tags.map((tag) => (
+        <a
+          href={`${BASE}tags/${encodeURIComponent(tag.tag)}/`}
+          class="p-4 rounded-lg border border-gray-200 dark:border-gray-800 hover:border-blue-500 flex items-center justify-between"
+        >
+          <span>#{tag.tag}</span>
+          <span class="text-sm text-gray-500">{tag.count}</span>
+        </a>
+      ))}
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -1,0 +1,47 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export async function getPublishedPosts() {
+  const posts = await getCollection('blog');
+  return posts
+    .filter((post) => post.data.status === 'published')
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}
+
+export function findPrevNext(posts: CollectionEntry<'blog'>[], slug: string) {
+  const index = posts.findIndex((p) => p.slug === slug);
+  return {
+    prev: index > 0 ? posts[index - 1] : undefined,
+    next: index >= 0 && index < posts.length - 1 ? posts[index + 1] : undefined,
+  };
+}
+
+export function findRelated(posts: CollectionEntry<'blog'>[], current: CollectionEntry<'blog'>, limit = 4) {
+  const tags = new Set(current.data.tags);
+  return posts
+    .filter((p) => p.slug !== current.slug && p.data.tags.some((t) => tags.has(t)))
+    .slice(0, limit);
+}
+
+export function groupByYearMonth(posts: CollectionEntry<'blog'>[]) {
+  const map = new Map<string, CollectionEntry<'blog'>[]>();
+  posts.forEach((post) => {
+    const d = post.data.date;
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    const list = map.get(key) ?? [];
+    list.push(post);
+    map.set(key, list);
+  });
+  return Array.from(map.entries())
+    .sort((a, b) => (a[0] < b[0] ? 1 : -1))
+    .map(([key, list]) => ({ key, posts: list.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf()) }));
+}
+
+export function collectTags(posts: CollectionEntry<'blog'>[]) {
+  const counts = new Map<string, number>();
+  posts.forEach((post) => {
+    post.data.tags.forEach((tag) => counts.set(tag, (counts.get(tag) ?? 0) + 1));
+  });
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([tag, count]) => ({ tag, count }));
+}

--- a/src/utils/rehypeCodeEnhance.ts
+++ b/src/utils/rehypeCodeEnhance.ts
@@ -1,0 +1,48 @@
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+import type { Element } from 'hast';
+
+const rehypeCodeEnhance: Plugin = () => {
+  return (tree) => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName !== 'pre') return;
+      const code = node.children.find(
+        (child): child is Element => child.type === 'element' && child.tagName === 'code'
+      );
+      if (!code) return;
+
+      const classList = (code.properties?.className as string[] | undefined) || [];
+      const langClass = classList.find((cls) => cls.startsWith('language-')) || 'language-text';
+      const language = langClass.replace('language-', '') || 'text';
+
+      node.properties = {
+        ...node.properties,
+        className: ['code-block', ...(node.properties?.className as string[] | undefined || [])],
+      };
+
+      const copyButton: Element = {
+        type: 'element',
+        tagName: 'button',
+        properties: {
+          className: ['code-copy'],
+          type: 'button',
+          'data-lang': language,
+        },
+        children: [{ type: 'text', value: 'Copy' }],
+      };
+
+      const label: Element = {
+        type: 'element',
+        tagName: 'span',
+        properties: {
+          className: ['code-lang'],
+        },
+        children: [{ type: 'text', value: language }],
+      };
+
+      node.children = [copyButton, label, ...node.children];
+    });
+  };
+};
+
+export default rehypeCodeEnhance;

--- a/src/utils/rehypeExternalLinks.ts
+++ b/src/utils/rehypeExternalLinks.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+import type { Element } from 'hast';
+
+interface Options {
+  target?: string;
+  rel?: string[];
+}
+
+const rehypeExternalLinks: Plugin<[Options?]> = (options = {}) => {
+  const target = options.target ?? '_blank';
+  const rel = options.rel ?? ['noopener', 'noreferrer'];
+
+  return (tree) => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName !== 'a') return;
+      const href = (node.properties?.href as string) || '';
+      if (!href || href.startsWith('#') || href.startsWith('/') || href.startsWith(import.meta.env.BASE_URL)) {
+        return;
+      }
+      node.properties = {
+        ...node.properties,
+        target,
+        rel: rel.join(' '),
+      };
+    });
+  };
+};
+
+export default rehypeExternalLinks;

--- a/src/utils/rehypeHeadingLinks.ts
+++ b/src/utils/rehypeHeadingLinks.ts
@@ -1,0 +1,42 @@
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+import type { Element } from 'hast';
+import slugify from 'slugify';
+
+const rehypeHeadingLinks: Plugin = () => {
+  return (tree) => {
+    visit(tree, 'element', (node: Element) => {
+      if (!/^h[1-6]$/.test(node.tagName)) return;
+      const text = extractText(node).trim();
+      if (!text) return;
+      const id = slugify(text, { lower: true, strict: true });
+      node.properties = { ...(node.properties || {}), id };
+
+      const anchor: Element = {
+        type: 'element',
+        tagName: 'a',
+        properties: {
+          href: `#${id}`,
+          className: ['heading-anchor'],
+          ariaLabel: `Link to ${text}`,
+        },
+        children: [{ type: 'text', value: '¶' }],
+      };
+
+      node.children = [...(node.children || []), anchor];
+    });
+  };
+};
+
+function extractText(node: Element): string {
+  if (!node.children) return '';
+  return node.children
+    .map((child) => {
+      if (child.type === 'text') return child.value;
+      if ((child as Element).children) return extractText(child as Element);
+      return '';
+    })
+    .join(' ');
+}
+
+export default rehypeHeadingLinks;

--- a/src/utils/remarkNotionCompat.ts
+++ b/src/utils/remarkNotionCompat.ts
@@ -1,0 +1,87 @@
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+import type { Root } from 'mdast';
+
+const invisibleReplacements: Record<string, string> = {
+  '\u00a0': ' ',
+  '\u2000': ' ',
+  '\u2001': ' ',
+  '\u2002': ' ',
+  '\u2003': ' ',
+  '\u2004': ' ',
+  '\u2005': ' ',
+  '\u2006': ' ',
+  '\u2007': ' ',
+  '\u2008': ' ',
+  '\u2009': ' ',
+  '\u200a': ' ',
+  '\u202f': ' ',
+  '\u3000': ' ',
+  '\u200b': '',
+  '\u200c': '',
+  '\u200d': '',
+  '\ufeff': '',
+};
+
+const notionCalloutEmoji = /^(💡|⚠️|📌|❗|✅|ℹ️|📣|📝)\s+/;
+
+const remarkNotionCompat: Plugin<[], Root> = () => {
+  return (tree) => {
+    // Normalize invisible characters and stray escapes
+    visit(tree, 'text', (node) => {
+      Object.entries(invisibleReplacements).forEach(([char, replacement]) => {
+        if (node.value.includes(char)) {
+          node.value = node.value.split(char).join(replacement);
+        }
+      });
+      // Notion sometimes escapes underscores in math/table content
+      node.value = node.value.replace(/\\_/g, '_');
+    });
+
+    // Ensure code blocks always have a language for Shiki
+    visit(tree, 'code', (node) => {
+      if (!node.lang || node.lang.trim() === '') {
+        node.lang = 'text';
+      }
+      // Trim extra blank lines that sneak in from Notion export
+      node.value = node.value.replace(/\n{3,}/g, '\n\n').trimEnd();
+    });
+
+    // Collapse excessive blank paragraphs from Notion
+    if (Array.isArray(tree.children)) {
+      const compacted: Root['children'] = [];
+      let blankStreak = 0;
+      for (const child of tree.children) {
+        const isBlankParagraph =
+          child.type === 'paragraph' &&
+          child.children?.every((c: any) => c.type === 'text' && c.value.trim() === '');
+        if (isBlankParagraph) {
+          blankStreak += 1;
+          if (blankStreak > 1) continue;
+        } else {
+          blankStreak = 0;
+        }
+        compacted.push(child);
+      }
+      tree.children = compacted;
+    }
+
+    // Degrade callout/toggle to blockquote with a label so it renders consistently
+    visit(tree, 'blockquote', (node) => {
+      const first = node.children?.[0];
+      if (first && first.type === 'paragraph') {
+        const textNode = first.children?.find((c: any) => c.type === 'text');
+        if (textNode && typeof textNode.value === 'string') {
+          textNode.value = textNode.value.replace(notionCalloutEmoji, '').trimStart();
+        }
+      }
+    });
+
+    // Tables from Notion sometimes lose alignment; ensure align array exists
+    visit(tree, 'table', (node: any) => {
+      if (!node.align) node.align = [];
+    });
+  };
+};
+
+export default remarkNotionCompat;


### PR DESCRIPTION
## Summary
- improve markdown rendering with GFM, KaTeX, code copy buttons, and Notion-specific cleanup
- add tag lists, archive view, pagination, prev/next/related navigation, and site-wide search modal
- generate a search index during workflows and include Notion sync before building

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e075b46548321980fda33c8fcb807)