### PR TITLE
Refactor code block rendering

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -56,13 +56,16 @@ const { title, description = "A minimal Astro blog", image = `${BASE}placeholder
       :root {
         scroll-behavior: smooth;
       }
-      pre.code-block {
+      .code-block {
         position: relative;
+      }
+      .code-block pre {
         overflow-x: auto;
         border-radius: 0.75rem;
         padding-top: 3.25rem;
+        margin: 0;
       }
-      .code-toolbar {
+      .code-block .code-toolbar {
         position: absolute;
         top: 0;
         right: 0;
@@ -73,7 +76,7 @@ const { title, description = "A minimal Astro blog", image = `${BASE}placeholder
         padding: 0.75rem 1rem 0;
         pointer-events: none;
       }
-      .code-lang {
+      .code-block .code-lang {
         text-transform: uppercase;
         font-size: 0.7rem;
         letter-spacing: 0.08em;

--- a/src/utils/rehypeCodeEnhance.ts
+++ b/src/utils/rehypeCodeEnhance.ts
@@ -2,43 +2,94 @@ import type { Plugin } from 'unified';
 import { visit } from 'unist-util-visit';
 import type { Element } from 'hast';
 
+type ClassName = string | string[] | undefined;
+
+const toClassList = (className: ClassName): string[] => {
+  if (!className) return [];
+  if (Array.isArray(className)) return className.filter(Boolean).map(String);
+  return className
+    .split(/\s+/)
+    .map((cls) => cls.trim())
+    .filter(Boolean);
+};
+
+const findLanguage = (pre: Element, code: Element): string => {
+  const classLanguages = [...toClassList(pre.properties?.className), ...toClassList(code.properties?.className)]
+    .map((cls) => (cls.startsWith('language-') ? cls.replace('language-', '') : undefined))
+    .filter(Boolean) as string[];
+
+  const dataLanguages = [
+    pre.properties?.dataLanguage as string | undefined,
+    pre.properties?.['data-language'] as string | undefined,
+    code.properties?.dataLanguage as string | undefined,
+    code.properties?.['data-language'] as string | undefined,
+  ].filter(Boolean) as string[];
+
+  const language = [...dataLanguages, ...classLanguages].find(Boolean);
+  return language && language.trim() ? language.trim() : 'text';
+};
+
+const createToolbar = (language: string): Element => ({
+  type: 'element',
+  tagName: 'div',
+  properties: {
+    className: ['code-toolbar'],
+  },
+  children: [
+    {
+      type: 'element',
+      tagName: 'span',
+      properties: {
+        className: ['code-lang'],
+      },
+      children: [{ type: 'text', value: language }],
+    },
+  ],
+});
+
 const rehypeCodeEnhance: Plugin = () => {
   return (tree) => {
-    visit(tree, 'element', (node: Element) => {
-      if (node.tagName !== 'pre') return;
+    visit(tree, 'element', (node: Element, index, parent) => {
+      if (!parent || node.tagName !== 'pre') return;
       const code = node.children.find(
         (child): child is Element => child.type === 'element' && child.tagName === 'code'
       );
       if (!code) return;
 
-      const classList = (code.properties?.className as string[] | undefined) || [];
-      const langClass = classList.find((cls) => cls.startsWith('language-')) || 'language-text';
-      const language = langClass.replace('language-', '') || 'text';
+      if (parent.type === 'element' && toClassList((parent as Element).properties?.className).includes('code-block')) {
+        return;
+      }
+
+      const language = findLanguage(node, code);
+
+      const preClassList = new Set(toClassList(node.properties?.className));
+      preClassList.delete('code-block');
 
       node.properties = {
         ...node.properties,
-        className: ['code-block', ...(node.properties?.className as string[] | undefined || [])],
+        className: Array.from(preClassList),
+        dataLanguage: language,
+        'data-language': language,
       };
 
-      const label: Element = {
-        type: 'element',
-        tagName: 'span',
-        properties: {
-          className: ['code-lang'],
-        },
-        children: [{ type: 'text', value: language }],
+      code.properties = {
+        ...code.properties,
+        dataLanguage: language,
+        'data-language': language,
       };
 
-      const toolbar: Element = {
+      const wrapper: Element = {
         type: 'element',
         tagName: 'div',
         properties: {
-          className: ['code-toolbar'],
+          className: ['code-block'],
+          dataLanguage: language,
+          'data-language': language,
         },
-        children: [label],
+        children: [createToolbar(language), node],
       };
 
-      node.children = [toolbar, ...node.children];
+      parent.children.splice(index!, 1, wrapper);
     });
   };
 };


### PR DESCRIPTION
## Summary
- wrap rendered code blocks in a dedicated container and overlay the toolbar outside the `<pre>` element
- normalize language detection across data attributes and class names and sync data-language on pre/code

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e152f481883219011ae912a1f1f64)