### PR TITLE
Wrap long links on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -186,6 +186,11 @@
   font-size: 0.95rem;
 }
 
+.prose a {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 @media (max-width: 640px) {
   .code-block__header {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- allow long links inside article prose to wrap so they don't overflow on small screens

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e6d4728648321adab454ca0291b01)