### PR TITLE
Fix mobile prose overflow handling

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -31,7 +31,7 @@ const commentsEnabled = post.data.comments ?? true;
     <div class="flex gap-8">
       <TableOfContents headings={headings} />
 
-      <article class="prose dark:prose-invert max-w-none prose-img:rounded-xl flex-1">
+      <article class="prose dark:prose-invert max-w-none prose-img:rounded-xl flex-1 min-w-0">
         <header class="mb-8 not-prose">
           {post.data.cover && (
             <img src={post.data.cover} alt={post.data.title} class="w-full h-64 object-cover rounded-xl mb-6" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,6 +22,59 @@
   --code-highlight-accent: rgb(96 165 250);
 }
 
+html,
+body {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+:where(.prose) {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+:where(.prose) :where(a) {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
+}
+
+:where(.prose) :where(code):not(:where(pre code)) {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
+}
+
+:where(.prose) :where(pre) {
+  overflow-x: auto;
+  white-space: pre;
+  word-break: normal;
+  -webkit-overflow-scrolling: touch;
+}
+
+:where(.prose) :where(pre) code {
+  white-space: inherit;
+  word-break: normal;
+}
+
+:where(.prose) :where(table) {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+:where(.prose) :where(table) > * {
+  min-width: max-content;
+}
+
+:where(.prose) :where(.katex-display),
+:where(.prose) :where(.math-display) {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .prose :where(figure.code-block) {
   margin: 1.25rem 0;
 }


### PR DESCRIPTION
## Summary
- add global wrap and overflow rules for prose content, links, math, and tables to stop mobile horizontal overflow
- keep preformatted code blocks scrollable while allowing inline code to wrap
- allow the article container to shrink within the post layout to avoid flex overflow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e70300c188321bd235ec2a32c2668)