### PR TITLE
Implement persistent global theme handling

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -10,20 +10,83 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
             <a href={`${BASE}about/`} class="hover:underline">About</a>
             <a href={`${BASE}rss.xml`} class="hover:underline">RSS</a>
             <button id="theme-toggle" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-800" aria-label="Toggle theme">
-                🌙/☀️
+                🖥️☀️
             </button>
         </nav>
     </div>
 </header>
 
 <script>
+    const storageKey = "theme";
+    const order = ["light", "dark", "system"];
+
+    const getPreference = () => {
+        try {
+            const value = localStorage.getItem(storageKey);
+            if (value && order.includes(value)) return value;
+        } catch (error) {
+            console.warn("Unable to read theme preference:", error);
+        }
+        return "system";
+    };
+
+    const getResolvedTheme = () =>
+        document.documentElement.classList.contains("dark") ? "dark" : "light";
+
+    const iconFor = (preference, resolved) => {
+        if (preference === "system") return resolved === "dark" ? "🖥️🌙" : "🖥️☀️";
+        return preference === "dark" ? "🌙" : "☀️";
+    };
+
+    const labelFor = (preference, resolved) => {
+        if (preference === "system") return `System (${resolved})`;
+        return preference === "dark" ? "Dark" : "Light";
+    };
+
+    const render = (preference, resolvedOverride) => {
+        const button = document.getElementById("theme-toggle");
+        if (!button) return;
+        const resolved = resolvedOverride ?? getResolvedTheme();
+        const icon = iconFor(preference, resolved);
+        const label = labelFor(preference, resolved);
+        button.dataset.theme = preference;
+        button.textContent = `${icon} ${label}`;
+        button.setAttribute("aria-label", `Toggle theme (current: ${label})`);
+    };
+
+    const applyPreference = (preference) => {
+        if (typeof window.__setTheme === "function") {
+            window.__setTheme(preference);
+            return;
+        }
+
+        const resolved =
+            preference === "dark" ||
+            (preference === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches)
+                ? "dark"
+                : "light";
+        document.documentElement.classList.toggle("dark", resolved === "dark");
+        try {
+            localStorage.setItem(storageKey, preference);
+        } catch (error) {
+            console.warn("Unable to persist theme preference:", error);
+        }
+        window.dispatchEvent(new CustomEvent("themechange", { detail: { theme: preference, resolved } }));
+    };
+
     const handleToggleClick = () => {
-        const element = document.documentElement;
-        element.classList.toggle("dark");
-    
-        const isDark = element.classList.contains("dark");
-        localStorage.setItem("theme", isDark ? "dark" : "light");
-    }
-    
+        const current = getPreference();
+        const next = order[(order.indexOf(current) + 1) % order.length];
+        applyPreference(next);
+        render(next);
+    };
+
     document.getElementById("theme-toggle")?.addEventListener("click", handleToggleClick);
+    render(getPreference());
+
+    window.addEventListener("themechange", (event) => {
+        const theme = event.detail?.theme ?? getPreference();
+        const resolved = event.detail?.resolved;
+        render(theme, resolved);
+    });
 </script>

--- a/src/components/ThemeScript.astro
+++ b/src/components/ThemeScript.astro
@@ -1,0 +1,66 @@
+---
+const themeInitializer = `(() => {
+  const storageKey = 'theme';
+  const className = 'dark';
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  const validThemes = ['light', 'dark', 'system'];
+  let currentPreference = (() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (stored && validThemes.includes(stored)) return stored;
+    } catch (error) {
+      console.warn('Unable to access localStorage for theme:', error);
+    }
+    return 'system';
+  })();
+
+  const resolveTheme = (preference) =>
+    preference === 'system' ? (mediaQuery.matches ? 'dark' : 'light') : preference;
+
+  const applyTheme = (preference) => {
+    const effectiveTheme = resolveTheme(preference);
+    document.documentElement.classList.toggle(className, effectiveTheme === 'dark');
+    document.documentElement.dataset.theme = effectiveTheme;
+    return effectiveTheme;
+  };
+
+  const dispatchChange = (preference) => {
+    const resolved = document.documentElement.classList.contains(className) ? 'dark' : 'light';
+    window.dispatchEvent(
+      new CustomEvent('themechange', {
+        detail: { theme: preference, resolved },
+      }),
+    );
+  };
+
+  const handleMatchChange = () => {
+    if (currentPreference !== 'system') return;
+    applyTheme('system');
+    dispatchChange('system');
+  };
+
+  applyTheme(currentPreference);
+  if (currentPreference === 'system') {
+    mediaQuery.addEventListener('change', handleMatchChange);
+  }
+
+  window.__setTheme = (next) => {
+    const preference = validThemes.includes(String(next)) ? String(next) : 'system';
+    currentPreference = preference;
+    try {
+      localStorage.setItem(storageKey, preference);
+    } catch (error) {
+      console.warn('Unable to persist theme selection:', error);
+    }
+    applyTheme(preference);
+    dispatchChange(preference);
+
+    if (preference === 'system') {
+      mediaQuery.addEventListener('change', handleMatchChange);
+    } else {
+      mediaQuery.removeEventListener('change', handleMatchChange);
+    }
+  };
+})();`;
+---
+<script is:inline set:html={themeInitializer}></script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import 'katex/dist/katex.min.css';
 import '../styles/global.css';
+import ThemeScript from '../components/ThemeScript.astro';
 
 interface Props {
   title: string;
@@ -16,6 +17,7 @@ const { title, description = "A minimal Astro blog", image = `${BASE}placeholder
 <!doctype html>
 <html lang="en">
   <head>
+    <ThemeScript />
     <meta charset="UTF-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width" />
@@ -34,25 +36,6 @@ const { title, description = "A minimal Astro blog", image = `${BASE}placeholder
     <meta name="twitter:image" content={image} />
     <title>{title}</title>
         
-    <!-- Dark Mode Script -->
-    <script is:inline>
-      const theme = (() => {
-        if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-          return localStorage.getItem('theme');
-        }
-        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-          return 'dark';
-        }
-        return 'light';
-      })();
-
-      if (theme === 'dark') {
-        document.documentElement.classList.add('dark');
-      } else {
-        document.documentElement.classList.remove('dark');
-      }
-    </script>
-
     <style>
       :root {
         scroll-behavior: smooth;


### PR DESCRIPTION
## Summary
- add an inline ThemeScript that resolves theme before paint, respects system preference, and dispatches themechange events
- include the theme initializer in the base layout so all pages share the same persisted theme
- update the header toggle to cycle light/dark/system, sync UI state, and notify other instances

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e74a7746c8321897ec651cd5d096d)