### PR TITLE
Simplify theme toggle to light and dark

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,7 +18,7 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
 
 <script>
     const storageKey = "theme";
-    const order = ["light", "dark", "system"];
+    const order = ["light", "dark"];
 
     const getPreference = () => {
         try {
@@ -27,28 +27,22 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
         } catch (error) {
             console.warn("Unable to read theme preference:", error);
         }
-        return "system";
+        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
     };
 
     const getResolvedTheme = () =>
         document.documentElement.classList.contains("dark") ? "dark" : "light";
 
-    const iconFor = (preference, resolved) => {
-        if (preference === "system") return resolved === "dark" ? "🖥️🌙" : "🖥️☀️";
-        return preference === "dark" ? "🌙" : "☀️";
-    };
+    const iconFor = (preference) => (preference === "dark" ? "🌙" : "☀️");
 
-    const labelFor = (preference, resolved) => {
-        if (preference === "system") return `System (${resolved})`;
-        return preference === "dark" ? "Dark" : "Light";
-    };
+    const labelFor = (preference) => (preference === "dark" ? "Dark" : "Light");
 
     const render = (preference, resolvedOverride) => {
         const button = document.getElementById("theme-toggle");
         if (!button) return;
         const resolved = resolvedOverride ?? getResolvedTheme();
-        const icon = iconFor(preference, resolved);
-        const label = labelFor(preference, resolved);
+        const icon = iconFor(resolved);
+        const label = labelFor(resolved);
         button.dataset.theme = preference;
         button.textContent = `${icon} ${label}`;
         button.setAttribute("aria-label", `Toggle theme (current: ${label})`);
@@ -60,11 +54,7 @@ const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL :
             return;
         }
 
-        const resolved =
-            preference === "dark" ||
-            (preference === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches)
-                ? "dark"
-                : "light";
+        const resolved = preference === "dark" ? "dark" : "light";
         document.documentElement.classList.toggle("dark", resolved === "dark");
         try {
             localStorage.setItem(storageKey, preference);

--- a/src/components/ThemeScript.astro
+++ b/src/components/ThemeScript.astro
@@ -3,7 +3,7 @@ const themeInitializer = `(() => {
   const storageKey = 'theme';
   const className = 'dark';
   const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-  const validThemes = ['light', 'dark', 'system'];
+  const validThemes = ['light', 'dark'];
   let currentPreference = (() => {
     try {
       const stored = localStorage.getItem(storageKey);
@@ -11,11 +11,10 @@ const themeInitializer = `(() => {
     } catch (error) {
       console.warn('Unable to access localStorage for theme:', error);
     }
-    return 'system';
+    return mediaQuery.matches ? 'dark' : 'light';
   })();
 
-  const resolveTheme = (preference) =>
-    preference === 'system' ? (mediaQuery.matches ? 'dark' : 'light') : preference;
+  const resolveTheme = (preference) => (preference === 'dark' ? 'dark' : 'light');
 
   const applyTheme = (preference) => {
     const effectiveTheme = resolveTheme(preference);
@@ -33,19 +32,10 @@ const themeInitializer = `(() => {
     );
   };
 
-  const handleMatchChange = () => {
-    if (currentPreference !== 'system') return;
-    applyTheme('system');
-    dispatchChange('system');
-  };
-
   applyTheme(currentPreference);
-  if (currentPreference === 'system') {
-    mediaQuery.addEventListener('change', handleMatchChange);
-  }
 
   window.__setTheme = (next) => {
-    const preference = validThemes.includes(String(next)) ? String(next) : 'system';
+    const preference = validThemes.includes(String(next)) ? String(next) : resolveTheme(currentPreference);
     currentPreference = preference;
     try {
       localStorage.setItem(storageKey, preference);
@@ -54,12 +44,6 @@ const themeInitializer = `(() => {
     }
     applyTheme(preference);
     dispatchChange(preference);
-
-    if (preference === 'system') {
-      mediaQuery.addEventListener('change', handleMatchChange);
-    } else {
-      mediaQuery.removeEventListener('change', handleMatchChange);
-    }
   };
 })();`;
 ---


### PR DESCRIPTION
## Summary
- remove the system theme option from the header toggle and align labels/icons to the resolved theme
- simplify the theme bootstrap script to only handle light and dark modes while still defaulting to user preference

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e773897fc8321a75d7adb76a367a9)