### PR TITLE
Improve TOC usability and refresh post cards

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,0 +1,50 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+interface PostWithStats extends CollectionEntry<'blog'> {
+  stats: { text: string; wordCount: number };
+}
+
+interface Props {
+  post: PostWithStats;
+  base: string;
+  index: number;
+}
+
+const { post, base, index } = Astro.props;
+const href = `${base}${post.slug}/`;
+---
+<li
+  class="group/card animate-card-in [animation-delay:calc(var(--card-index)*45ms)]"
+  style={`--card-index:${index}`}
+>
+  <a
+    href={href}
+    class="relative block h-full overflow-hidden rounded-2xl border border-gray-200/80 bg-white/75 shadow-sm ring-1 ring-gray-100/60 transition-transform duration-200 ease-out will-change-transform hover:-translate-y-1 hover:shadow-lg hover:ring-blue-500/30 hover:border-blue-200/80 active:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 dark:border-gray-800/80 dark:bg-gray-900/70 dark:ring-gray-900/70 dark:hover:border-blue-700/70 dark:hover:ring-blue-700/30"
+  >
+    {post.data.cover && (
+      <div class="relative overflow-hidden">
+        <div class="absolute inset-0 bg-gradient-to-t from-black/10 to-transparent opacity-70 transition-opacity duration-300 ease-out group-hover/card:opacity-90"></div>
+        <img
+          src={post.data.cover}
+          alt={post.data.title}
+          class="h-48 w-full object-cover transition duration-300 ease-out group-hover/card:scale-[1.01] group-focus-visible/card:scale-[1.01] motion-reduce:transform-none"
+          loading="lazy"
+        />
+      </div>
+    )}
+
+    <div class="space-y-3 p-5">
+      <h3 class="text-xl font-semibold text-gray-900 transition-colors group-hover/card:text-blue-600 group-focus-visible/card:text-blue-600 dark:text-gray-100 dark:group-hover/card:text-blue-300">
+        <span class="underline-offset-4 group-hover/card:underline">{post.data.title}</span>
+      </h3>
+      <div class="text-sm text-gray-500 flex flex-wrap items-center gap-3 dark:text-gray-400">
+        <span class="flex items-center gap-1">📅 {post.data.date.toLocaleDateString()}</span>
+        <span class="flex items-center gap-1">✍️ {post.stats.wordCount} 字</span>
+        <span class="flex items-center gap-1" title={`${post.stats.wordCount} words`}>
+          ⏱️ {post.stats.text}
+        </span>
+      </div>
+    </div>
+  </a>
+</li>

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,6 +1,7 @@
 ---
 import { getReadingTime } from '../utils/readingTime';
 import type { CollectionEntry } from 'astro:content';
+import PostCard from './PostCard.astro';
 
 interface Props {
   posts: CollectionEntry<'blog'>[];
@@ -8,26 +9,10 @@ interface Props {
 
 const BASE = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
 const { posts } = Astro.props;
-const enriched = posts.map((post) => ({ ...post, stats: getReadingTime(post.body) }));
+const enriched = posts.map((post, index) => ({ ...post, stats: getReadingTime(post.body), index }));
 ---
-<ul class="space-y-8" id="post-list">
+<ul class="grid gap-6" id="post-list">
   {enriched.map((post) => (
-    <li class="border-b border-gray-200 dark:border-gray-800 pb-8 last:border-0">
-      <a href={`${BASE}${post.slug}/`} class="group block">
-        {post.data.cover && (
-          <img src={post.data.cover} alt={post.data.title} class="w-full h-48 object-cover rounded-lg mb-4" />
-        )}
-        <h3 class="text-xl font-semibold group-hover:text-blue-600 dark:group-hover:text-blue-400 mb-2">
-          {post.data.title}
-        </h3>
-        <div class="text-sm text-gray-500 mb-2 flex items-center gap-3 flex-wrap">
-          <span class="flex items-center gap-1">📅 {post.data.date.toLocaleDateString()}</span>
-          <span class="flex items-center gap-1">✍️ {post.stats.wordCount} 字</span>
-          <span class="flex items-center gap-1" title={`${post.stats.wordCount} words`}>
-            ⏱️ {post.stats.text}
-          </span>
-        </div>
-      </a>
-    </li>
+    <PostCard post={post} base={BASE} index={post.index} />
   ))}
 </ul>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -13,29 +13,68 @@ const headings = Astro.props.headings
   .filter((heading) => heading.depth <= 3)
   .map((heading) => ({
     ...heading,
-    indentClass: heading.depth === 3 ? 'pl-3' : '',
+    indentClass:
+      heading.depth === 3
+        ? 'pl-4 border-l border-dashed border-gray-200 dark:border-gray-700'
+        : '',
   }));
 ---
 
-<aside class="hidden lg:block w-64 shrink-0">
-  <div class="sticky top-24 space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4 shadow-sm dark:border-gray-800 dark:bg-gray-800/40">
+<aside class="lg:w-72 shrink-0" aria-label="文章目录">
+  <div class="mb-4 flex items-center justify-between lg:hidden">
     <div>
       <p class="text-sm font-semibold text-gray-900 dark:text-gray-100">文章目录</p>
-      <p class="text-xs text-gray-500 dark:text-gray-400">快速跳转到你关心的章节</p>
+      <p class="text-xs text-gray-500 dark:text-gray-400">快速跳转章节</p>
     </div>
+    <button
+      type="button"
+      class="rounded-full border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:-translate-y-0.5 hover:border-blue-200 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:border-blue-700 dark:hover:text-blue-300"
+      data-toc-toggle
+      aria-expanded="false"
+    >
+      目录
+    </button>
+  </div>
+
+  <div
+    id="toc-panel"
+    class="hidden lg:block rounded-2xl border border-gray-200/80 bg-white/75 backdrop-blur-sm shadow-sm ring-1 ring-gray-100/40 dark:border-gray-800 dark:bg-gray-900/70 dark:ring-gray-900/60 lg:sticky lg:top-24 lg:max-h-[calc(100vh-8rem)] lg:overflow-hidden"
+  >
+    <div class="flex items-center justify-between gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-800">
+      <div>
+        <p class="text-sm font-semibold text-gray-900 dark:text-gray-100">文章目录</p>
+        <p class="text-xs text-gray-500 dark:text-gray-400">点击平滑跳转，当前章节高亮</p>
+      </div>
+      <button
+        type="button"
+        class="rounded-full p-2 text-gray-500 transition hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-400 dark:hover:text-gray-100 lg:hidden"
+        data-toc-close
+        aria-label="关闭目录"
+      >
+        ✕
+      </button>
+    </div>
+
     {headings.length === 0 ? (
-      <p class="text-sm text-gray-500 dark:text-gray-400">本文暂无目录。</p>
+      <p class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">本文暂无目录。</p>
     ) : (
-      <nav aria-label="文章目录">
-        <ol class="space-y-2 text-sm">
+      <nav
+        aria-label="文章目录"
+        class="max-h-[65vh] overflow-y-auto lg:max-h-[calc(100vh-12rem)]"
+        data-toc-list
+      >
+        <ol class="space-y-1 px-2 py-3 text-sm">
           {headings.map((heading) => (
             <li>
               <a
                 href={`#${heading.slug}`}
-                class={`flex items-start gap-2 text-gray-700 underline-offset-2 transition hover:text-blue-600 dark:text-gray-200 dark:hover:text-blue-400 ${heading.indentClass}`}
+                class={`group flex items-start gap-2 rounded-lg px-2 py-2 text-gray-700 underline-offset-4 transition hover:bg-gray-100 hover:text-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-blue-400 ${heading.indentClass}`}
+                data-toc-link
+                data-slug={heading.slug}
+                title={heading.text}
               >
-                <span class="mt-0.5 text-xs text-gray-400 dark:text-gray-500">#</span>
-                <span>{heading.text}</span>
+                <span class="mt-0.5 text-xs text-gray-400 transition group-hover:text-blue-500 dark:text-gray-500 dark:group-hover:text-blue-300">#</span>
+                <span class="flex-1 truncate" data-toc-text>{heading.text}</span>
               </a>
             </li>
           ))}
@@ -44,3 +83,101 @@ const headings = Astro.props.headings
     )}
   </div>
 </aside>
+
+<script>
+  const tocPanel = document.getElementById('toc-panel');
+  const toggleButtons = document.querySelectorAll('[data-toc-toggle]');
+  const closeButton = document.querySelector('[data-toc-close]');
+  const tocLinks = Array.from(document.querySelectorAll('[data-toc-link]'));
+  const headings = Array.from(
+    document.querySelectorAll('[data-article] h2[id], [data-article] h3[id]')
+  );
+
+  const headerOffset = 88; // 预留给站点 Header 的高度，避免锚点被遮挡
+
+  const openMobileToc = () => {
+    if (!tocPanel) return;
+    tocPanel.classList.remove('hidden');
+    tocPanel.classList.add('block', 'fixed', 'inset-x-4', 'top-24', 'bottom-6', 'z-40', 'overflow-hidden');
+    tocPanel.setAttribute('aria-modal', 'true');
+    toggleButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'true'));
+  };
+
+  const closeMobileToc = (resetOnly = false) => {
+    if (!tocPanel) return;
+    tocPanel.classList.remove('fixed', 'inset-x-4', 'top-24', 'bottom-6', 'z-40', 'overflow-hidden', 'block');
+    if (!resetOnly) {
+      tocPanel.classList.add('hidden');
+      toggleButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'false'));
+    }
+    tocPanel.removeAttribute('aria-modal');
+  };
+
+  toggleButtons.forEach((btn) => {
+    btn.addEventListener('click', () => openMobileToc());
+  });
+
+  closeButton?.addEventListener('click', () => closeMobileToc());
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth >= 1024) {
+      closeMobileToc(true);
+      tocPanel?.classList.remove('hidden');
+    } else {
+      // 小屏回到默认收起状态，避免在缩放后遮挡正文
+      closeMobileToc();
+    }
+  });
+
+  const setActiveLink = (slug) => {
+    tocLinks.forEach((link) => {
+      const isActive = slug && link.dataset.slug === slug;
+      link.classList.toggle('text-blue-600', isActive);
+      link.classList.toggle('dark:text-blue-300', isActive);
+      link.classList.toggle('font-semibold', isActive);
+      link.setAttribute('aria-current', isActive ? 'location' : 'false');
+    });
+  };
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (headings.length > 0) {
+    setActiveLink(headings[0].id);
+  }
+
+  tocLinks.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      const slug = link.dataset.slug;
+      if (!slug) return;
+      const target = document.getElementById(slug);
+      if (!target) return;
+
+      event.preventDefault();
+      const top = target.getBoundingClientRect().top + window.scrollY - headerOffset;
+      window.scrollTo({ top, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+
+      if (window.innerWidth < 1024) {
+        closeMobileToc();
+      }
+    });
+  });
+
+  if ('IntersectionObserver' in window && headings.length > 0) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveLink(entry.target.id);
+          }
+        });
+      },
+      {
+        // 在视口中线稍偏上的区域判定为“当前章节”
+        rootMargin: '-40% 0px -45% 0px',
+        threshold: [0, 1],
+      }
+    );
+
+    headings.forEach((heading) => observer.observe(heading));
+  }
+</script>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -30,10 +30,13 @@ const commentsEnabled = post.data.comments ?? true;
   <ReadingProgress />
   <Header />
   <main class="container mx-auto px-4 py-8 max-w-6xl">
-    <div class="flex gap-8">
+    <div class="flex gap-6 lg:gap-10">
       <TableOfContents headings={headings} />
 
-      <article class="prose dark:prose-invert max-w-none prose-img:rounded-xl flex-1 min-w-0" data-article>
+      <article
+        class="prose dark:prose-invert max-w-none prose-img:rounded-xl flex-1 min-w-0 lg:max-w-3xl xl:max-w-4xl"
+        data-article
+      >
         <header class="mb-8 not-prose">
           {post.data.cover && (
             <img src={post.data.cover} alt={post.data.title} class="w-full h-64 object-cover rounded-xl mb-6" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  /* 首页卡片淡入动画，停留在当前状态避免重排 */
+  .animate-card-in {
+    animation: card-in 280ms ease-out both;
+  }
+}
+
+@keyframes card-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-card-in {
+    animation: none;
+  }
+}
+
 :root {
   --code-font: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   --code-radius: 0.9rem;


### PR DESCRIPTION
## Summary
- keep the article table of contents visible with sticky positioning, mobile toggle, smooth scrolling, and active section highlighting
- tighten article layout widths so the new sticky TOC doesn’t overlap the main prose
- refresh home post cards with layered borders/shadows, hover/focus states, and gentle fade-in animation with reduced-motion fallback

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed36455088321870f7ec2eed34625)