### PR TITLE
Automate Notion sync PR auto-merge

### DIFF
--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -31,9 +31,23 @@ jobs:
           NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
         run: npm run notion:sync
 
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet --exit-code -- src/content/blog/notion/ public/images/notion/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No content changes detected."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git status --short
+          fi
+
       - name: Create Pull Request
+        id: create_pull_request
+        if: steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || github.token }}
           commit-message: "chore: sync content from Notion"
           branch: chore/sync-notion-content
           title: "chore: sync content from Notion"
@@ -45,3 +59,56 @@ jobs:
           add-paths: |
             src/content/blog/notion/
             public/images/notion/
+          delete-branch: false
+
+      - name: Enable auto-merge
+        if: steps.changes.outputs.changed == 'true' && steps.create_pull_request.outputs.pull-request-number != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PAT != '' && secrets.GH_PAT || github.token }}
+          script: |
+            const prNumber = Number('${{ steps.create_pull_request.outputs.pull-request-number }}');
+            if (!prNumber) {
+              core.setFailed('Pull request number not available for auto-merge.');
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const pullRequestId = pr.node_id;
+
+            try {
+              await github.graphql(
+                `mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                  enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {
+                    pullRequest { number autoMergeRequest { enabledAt } }
+                  }
+                }`,
+                {
+                  pullRequestId,
+                  mergeMethod: 'SQUASH',
+                  headers: { Accept: 'application/vnd.github.merge-info-preview+json' },
+                }
+              );
+              core.info(`Auto-merge enabled for PR #${prNumber} with squash.`);
+            } catch (error) {
+              core.warning(`Failed to enable squash auto-merge: ${error.message}`);
+              core.info('Attempting to enable merge-commit auto-merge as fallback.');
+
+              await github.graphql(
+                `mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                  enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {
+                    pullRequest { number autoMergeRequest { enabledAt } }
+                  }
+                }`,
+                {
+                  pullRequestId,
+                  mergeMethod: 'MERGE',
+                  headers: { Accept: 'application/vnd.github.merge-info-preview+json' },
+                }
+              );
+              core.info(`Auto-merge enabled for PR #${prNumber} with merge commit.`);
+            }


### PR DESCRIPTION
## Summary
- add change detection to skip PR creation when Notion sync has no diff
- create Notion sync PRs with PAT fallback and enable GitHub auto-merge
- keep branch cleanup via existing workflow while preventing auto deletion before merge

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694efc82f02c8321a2f70d2f09182afc)