### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/yuanlehome/blog/security/code-scanning/1](https://github.com/yuanlehome/blog/security/code-scanning/1)

To fix this, explicitly restrict the `GITHUB_TOKEN` permissions in the workflow. The cleanest approach without changing functionality is to add a `permissions` block that grants only read access to repository contents, which is sufficient for `actions/checkout` and typical Node-based CI steps. This can be done at the workflow root (applies to all jobs) or at the job level; here we will add it at the workflow root, right below `name: CI`, so every job inherits `contents: read` unless overridden later.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after the `name: CI` line (line 1). No other changes, imports, or additions are required, and this will not affect the current behavior of the CI job, as it only tightens unused write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
