### PR TITLE
优化移动端 TOC 展开/关闭缩放动效并修复滚动抖动

### DIFF
--- a/src/components/MobileToc.astro
+++ b/src/components/MobileToc.astro
@@ -49,7 +49,7 @@ const showTrigger = Astro.props.showTrigger ?? false;
       role="dialog"
       aria-modal="true"
       aria-label="文章目录"
-      class="absolute inset-x-0 bottom-0 translate-y-full rounded-t-2xl border border-zinc-200 bg-neutral-50/95 shadow-2xl ring-1 ring-black/5 transition duration-200 data-[open=true]:translate-y-0 dark:border-zinc-800 dark:bg-zinc-900/95 dark:ring-white/10"
+      class="absolute inset-x-3 bottom-6 origin-[var(--mobile-toc-origin,calc(100%-1.5rem)_calc(100%-1.5rem))] scale-[0.12] opacity-0 rounded-2xl border border-zinc-200 bg-neutral-50/95 shadow-2xl ring-1 ring-black/5 transition-[transform,opacity] duration-250 ease-out data-[open=true]:scale-100 data-[open=true]:opacity-100 dark:border-zinc-800 dark:bg-zinc-900/95 dark:ring-white/10"
       data-mobile-toc-drawer
     >
       <div class="flex items-center justify-between gap-3 px-4 pt-4 pb-3">
@@ -65,7 +65,7 @@ const showTrigger = Astro.props.showTrigger ?? false;
           关闭
         </button>
       </div>
-      <div class="max-h-[60vh] overflow-y-auto px-4 pb-5" data-mobile-toc-scroll>
+      <div class="max-h-[65vh] overflow-y-auto px-4 pb-5" data-mobile-toc-scroll>
         <ol class="space-y-3 text-sm">
           <TocTree nodes={tocForest} />
         </ol>
@@ -88,9 +88,7 @@ const showTrigger = Astro.props.showTrigger ?? false;
       (tocDrawer ?? tocRoot)?.querySelectorAll('[data-mobile-toc-link]') ?? [],
     ) as HTMLAnchorElement[];
   const body = document.body;
-  const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  const prefersReduce = reducedMotionQuery.matches;
-
+  const docEl = document.documentElement;
   const getHeaderOffset = (): number => {
     const headerHeightStr = getComputedStyle(document.documentElement).getPropertyValue(
       '--site-header-height',
@@ -125,20 +123,44 @@ const showTrigger = Astro.props.showTrigger ?? false;
 
   const lockScroll = () => {
     scrollYBeforeLock = window.scrollY;
+    const scrollbarWidth = window.innerWidth - docEl.clientWidth;
+    docEl.style.overflow = 'hidden';
     body.style.position = 'fixed';
     body.style.width = '100%';
     body.style.top = `-${scrollYBeforeLock}px`;
+    if (scrollbarWidth > 0) {
+      body.style.paddingRight = `${scrollbarWidth}px`;
+    }
   };
 
   const unlockScroll = () => {
+    docEl.style.overflow = '';
     body.style.position = '';
     body.style.width = '';
     body.style.top = '';
+    body.style.paddingRight = '';
     window.scrollTo({ top: scrollYBeforeLock });
+  };
+
+  const syncDrawerOriginFromTrigger = () => {
+    if (!tocDrawer) return;
+    const trigger = getTocOpenButtons()[0];
+    if (!trigger) {
+      tocDrawer.style.removeProperty('--mobile-toc-origin');
+      return;
+    }
+
+    const rect = trigger.getBoundingClientRect();
+    const originX = rect.left + rect.width / 2;
+    const originY = rect.top + rect.height / 2;
+    tocDrawer.style.setProperty('--mobile-toc-origin', `${originX}px ${originY}px`);
   };
 
   const setOpen = (open: boolean) => {
     if (!tocRoot || !tocDrawer) return;
+    if (open) {
+      syncDrawerOriginFromTrigger();
+    }
     tocRoot.dataset.open = String(open);
     tocDrawer.dataset.open = String(open);
     tocBackdrop?.setAttribute('data-open', String(open));
@@ -178,6 +200,7 @@ const showTrigger = Astro.props.showTrigger ?? false;
   };
 
   syncOpenButtons();
+  syncDrawerOriginFromTrigger();
 
   const openButtonObserver = new MutationObserver(syncOpenButtons);
   openButtonObserver.observe(document.body, {
@@ -211,6 +234,8 @@ const showTrigger = Astro.props.showTrigger ?? false;
   window.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') setOpen(false);
   });
+
+  window.addEventListener('resize', syncDrawerOriginFromTrigger);
 
   applyScrollMargin();
   window.addEventListener('headerheightchange', applyScrollMargin);


### PR DESCRIPTION
### Motivation
- 改善移动端目录（TOC）的展开/关闭视觉体验，使目录从触发按钮位置“由小到大”缩放展开并在关闭时回到原位。
- 修复展开后直接关闭可能造成的页面位移/抖动，保证不点击章节跳转时关闭目录后文章页面位置保持不变。

### Description
- 在 `src/components/MobileToc.astro` 中将抽屉动效从 `translateY` 改为基于 `scale` + `opacity` 的过渡，并通过 `--mobile-toc-origin` 动态设置 `transform-origin`，实现从触发按钮位置放大/缩回的效果。
- 新增 `syncDrawerOriginFromTrigger`，在打开时和窗口 `resize` 时计算触发按钮位置并设置 CSS 变量，确保动画起点与按钮对齐；打开时也会调用该函数以同步原点。
- 优化滚动锁定逻辑：打开时记录滚动位置并设置 `document.documentElement.style.overflow='hidden'` 与 `body` 固定定位，同时加入滚动条宽度补偿（`body.style.paddingRight`），关闭时恢复并滚动回原位置，避免横向抖动。
- 将目录可滚动区高度从 `60vh` 调整为 `65vh`，并删除了未使用的 `prefers-reduced-motion` 代码。

### Testing
- 运行 `npm run check`（`astro check`），结果显示无错误或提示已解决。
- 运行 `npm run build` 成功完成静态站点构建，构建过程与静态路由生成均无异常。
- 在开发服务器下结合移动视口使用 Playwright 脚本进行交互验证（打开页面、点击 `data-mobile-toc-open` 展开、截图、点击 `data-mobile-toc-close` 关闭并截图），生成了 `artifacts/mobile-toc-open.png` 和 `artifacts/mobile-toc-closed.png`，交互与滚动保持行为符合预期。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699581989e3c832180839efb7292b798)