### PR TITLE
feat: 支持文章页图片点击放大预览

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -214,7 +214,7 @@ const tocPosition = layoutConfig.toc.position;
 
 <dialog
   id="article-image-zoom-dialog"
-  class="fixed inset-0 m-0 max-h-none max-w-none border-0 bg-black/85 p-0 backdrop:bg-black/85"
+  class="fixed inset-0 m-0 max-h-none max-w-none border-0 bg-black/85 p-0 backdrop:bg-black/85 [&[open]]:flex [&[open]]:items-center [&[open]]:justify-center"
   aria-label="图片预览"
 >
   <button
@@ -228,7 +228,7 @@ const tocPosition = layoutConfig.toc.position;
   <img
     data-image-zoom-preview
     alt=""
-    class="mx-auto max-h-[90vh] max-w-[90vw] object-contain"
+    class="max-h-[90vh] max-w-[90vw] object-contain"
     loading="eager"
     decoding="async"
   />


### PR DESCRIPTION
### Motivation

- 为文章正文图片提供更好的阅读体验，通过点击或键盘操作查看大图预览以便细节查看。
- 避免影响文章封面图（`data-post-cover`），只对正文内插图启用放大交互。

### Description

- 在文章页主内容容器的 `<article>` 上添加 `prose-img:cursor-zoom-in` 交互提示以表明图片可点击放大（`src/pages/[...slug].astro`）。
- 新增一个全屏 `dialog#article-image-zoom-dialog` 作为图片预览层，包含关闭按钮和图片预览节点。 
- 注入前端脚本为正文内的所有 `img` 注册点击及键盘（Enter/Space）事件以打开预览，同时为图片添加无障碍属性（`tabindex`、`role`、`aria-label`）；排除带有 `data-post-cover` 的封面图。 
- 支持通过关闭按钮、点击遮罩层或按 ESC（`cancel` 事件）关闭预览，并在关闭时清理预览图片的 `src` 与 `alt`，避免残留状态。

### Testing

- 运行 `npm run check`（Astro type/content checks）执行通过。 
- 运行 `npm run build`（包含 `prebuild` 渲染 mermaid）构建通过且生成静态站点成功。 
- 尝试通过 Playwright 脚本进行自动化截图以验证点击行为时，容器内 Chromium 启动时报错导致脚本执行失败。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ca4571c0832193cba18b6d392359)