### PR TITLE
Fix Mermaid image path handling and rendering (withBase + diagnostics + CSS tweaks)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,14 +23,14 @@ export default defineConfig({
   trailingSlash: 'always',
   integrations: [tailwind(), sitemap()],
   vite: {
-    plugins: [yaml()]
+    plugins: [yaml()],
   },
   markdown: {
     remarkPlugins: [
       remarkMath,
       remarkGfm,
       remarkNotionCompat,
-      remarkMermaid,
+      [remarkMermaid, { base: siteBase }],
       remarkCodeMeta,
       [remarkPrefixImages, { base: siteBase }],
     ],

--- a/src/lib/markdown/remarkMermaid.ts
+++ b/src/lib/markdown/remarkMermaid.ts
@@ -14,7 +14,9 @@ import type { Root, Code, HTML } from 'mdast';
 import type { VFile } from 'vfile';
 import { visit } from 'unist-util-visit';
 import { createHash } from 'crypto';
+import { existsSync } from 'fs';
 import { dirname, join } from 'path';
+import { withBase } from '../site/withBase';
 
 const GENERATED_ROOT = 'generated/mermaid';
 const DEFAULT_SEQUENCE_MODE = 'loose' as const;
@@ -146,7 +148,11 @@ function buildDualImageHtml(lightSrc: string, darkSrc: string, alt: string): str
   return `<span class="mermaid-dual-image"><img src="${lightSrc}" alt="${escapedAlt}" loading="lazy" decoding="async" data-theme="light" class="mermaid-dual-image__img mermaid-dual-image__img--light" /><img src="${darkSrc}" alt="${escapedAlt}" loading="lazy" decoding="async" data-theme="dark" class="mermaid-dual-image__img mermaid-dual-image__img--dark" /></span>`;
 }
 
-const remarkMermaid: Plugin<[], Root> = () => {
+interface RemarkMermaidOptions {
+  base?: string;
+}
+
+const remarkMermaid: Plugin<[RemarkMermaidOptions?], Root> = (pluginOptions = {}) => {
   return (tree: Root, file: VFile): void => {
     const targets: Array<{ node: Code; index: number; parent: Root['children'][0] }> = [];
 
@@ -161,6 +167,8 @@ const remarkMermaid: Plugin<[], Root> = () => {
     const existingCover: string | undefined = (file.data as any)?.astro?.frontmatter?.cover;
     let coverSet = Boolean(existingCover);
     const slug = resolveMermaidSlug(file.path);
+    const base = pluginOptions.base ?? '/';
+    const debugEnabled = process.env.DEBUG_MERMAID === '1';
 
     for (const { node, index, parent } of targets) {
       const code = node.value.trim();
@@ -169,9 +177,39 @@ const remarkMermaid: Plugin<[], Root> = () => {
       const lightPath = mermaidImagePath(code, options, slug, 'light');
       const darkPath = mermaidImagePath(code, options, slug, 'dark');
 
+      const lightPublicPath = mermaidAbsolutePath(
+        code,
+        join(file.cwd ?? process.cwd(), 'public'),
+        options,
+        slug,
+        'light',
+      );
+      const darkPublicPath = mermaidAbsolutePath(
+        code,
+        join(file.cwd ?? process.cwd(), 'public'),
+        options,
+        slug,
+        'dark',
+      );
+
+      if (!existsSync(lightPublicPath) || !existsSync(darkPublicPath)) {
+        console.warn(
+          `[remarkMermaid] Missing rendered assets for ${file.path ?? 'unknown file'}: ${lightPublicPath} | ${darkPublicPath}. Keeping code block fallback.`,
+        );
+        continue;
+      }
+
+      const lightSrc = withBase(lightPath, base);
+      const darkSrc = withBase(darkPath, base);
+
+      if (debugEnabled) {
+        console.debug(`[remarkMermaid] abs=${lightPublicPath} rel=${lightPath} src=${lightSrc}`);
+        console.debug(`[remarkMermaid] abs=${darkPublicPath} rel=${darkPath} src=${darkSrc}`);
+      }
+
       const htmlNode: HTML = {
         type: 'html',
-        value: buildDualImageHtml(lightPath, darkPath, title),
+        value: buildDualImageHtml(lightSrc, darkSrc, title),
       };
       (parent as any).children.splice(index, 1, htmlNode);
 

--- a/src/lib/site/assetUrl.ts
+++ b/src/lib/site/assetUrl.ts
@@ -1,3 +1,5 @@
+import { withBaseFromEnv } from './withBase';
+
 /**
  * Resolves asset URL by prefixing with BASE_URL if needed
  * Handles absolute paths that should be prefixed with the site base
@@ -7,19 +9,5 @@
  */
 export function resolveAssetUrl(url: string | undefined | null): string | undefined {
   if (!url) return undefined;
-
-  // External URLs (http://, https://, //) should not be prefixed
-  if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('//')) {
-    return url;
-  }
-
-  // If it's an absolute path starting with /, prefix with BASE_URL
-  if (url.startsWith('/')) {
-    const base = import.meta.env.BASE_URL;
-    const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
-    return `${normalizedBase}${url}`;
-  }
-
-  // Relative paths are returned as-is
-  return url;
+  return withBaseFromEnv(url);
 }

--- a/src/lib/site/withBase.ts
+++ b/src/lib/site/withBase.ts
@@ -1,0 +1,28 @@
+export function normalizeBase(base: string): string {
+  if (!base) return '/';
+  const prefixed = base.startsWith('/') ? base : `/${base}`;
+  if (prefixed === '/') return '/';
+  return prefixed.endsWith('/') ? prefixed : `${prefixed}/`;
+}
+
+export function withBase(path: string, base: string): string {
+  if (!path) return path;
+  if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('//')) {
+    return path;
+  }
+  if (!path.startsWith('/')) return path;
+
+  const normalizedBase = normalizeBase(base);
+  if (normalizedBase === '/') return path;
+
+  const basePrefix = normalizedBase.slice(0, -1);
+  if (path === basePrefix || path.startsWith(`${basePrefix}/`)) {
+    return path;
+  }
+
+  return `${basePrefix}${path}`;
+}
+
+export function withBaseFromEnv(path: string): string {
+  return withBase(path, import.meta.env.BASE_URL);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -409,10 +409,13 @@ body {
 .mermaid-dual-image {
   display: block;
   margin: 1.5rem auto;
+  overflow-x: auto;
 }
 
 .mermaid-dual-image__img {
+  display: block;
   width: 100%;
+  max-width: 100%;
   height: auto;
   border-radius: 0.5rem;
 }

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -228,6 +228,49 @@ test.describe('Blog smoke journey', () => {
     await mobileContext.close();
   });
 
+  test('mermaid diagrams load without 404s', async ({ page }) => {
+    await page.goto('/');
+
+    const postLinks = await page
+      .locator('#post-list li h3 a')
+      .evaluateAll((anchors: HTMLAnchorElement[]) =>
+        anchors
+          .map((anchor: HTMLAnchorElement) => anchor.getAttribute('href') || '')
+          .filter(Boolean),
+      );
+
+    const failedRequests: string[] = [];
+    page.on('response', (response) => {
+      if (response.status() >= 400 && response.url().includes('/generated/mermaid/')) {
+        failedRequests.push(`${response.status()} ${response.url()}`);
+      }
+    });
+
+    let found = false;
+    for (const href of postLinks) {
+      await page.goto(href);
+      const mermaidImage = page.locator('img[alt="Mermaid Diagram"]').first();
+      if ((await mermaidImage.count()) === 0) continue;
+
+      found = true;
+      await mermaidImage.waitFor({ state: 'visible' });
+      await expect
+        .poll(async () => mermaidImage.evaluate((img) => (img as HTMLImageElement).naturalWidth))
+        .toBeGreaterThan(0);
+      break;
+    }
+
+    if (!found) {
+      test.info().annotations.push({
+        type: 'todo',
+        description: 'No post with Mermaid diagram found for Mermaid e2e test',
+      });
+      return;
+    }
+
+    expect(failedRequests).toEqual([]);
+  });
+
   test('mobile viewport avoids horizontal overflow on flashattention page', async ({ browser }) => {
     const context = await browser.newContext({ viewport: { width: 375, height: 812 } });
     const mobilePage = await context.newPage();

--- a/tests/unit/remark-mermaid.test.ts
+++ b/tests/unit/remark-mermaid.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Root } from 'mdast';
+import { VFile } from 'vfile';
+import remarkMermaid, {
+  mermaidImagePath,
+  parseMermaidOptions,
+  resolveMermaidSlug,
+} from '../../src/lib/markdown/remarkMermaid';
+
+const cleanupDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    cleanupDirs
+      .splice(0)
+      .map(async (dir) =>
+        import('node:fs/promises').then((fs) => fs.rm(dir, { recursive: true, force: true })),
+      ),
+  );
+});
+
+describe('remarkMermaid', () => {
+  it('emits base-prefixed image src when rendered assets exist', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'remark-mermaid-'));
+    cleanupDirs.push(rootDir);
+    const publicDir = join(rootDir, 'public');
+    const filePath = join(rootDir, 'src/content/blog/notion/test.md');
+    const code = 'graph TD\nA-->B';
+    const slug = resolveMermaidSlug(filePath);
+    const options = parseMermaidOptions(undefined);
+
+    const lightPath = mermaidImagePath(code, options, slug, 'light').replace(/^\//, '');
+    const darkPath = mermaidImagePath(code, options, slug, 'dark').replace(/^\//, '');
+    await mkdir(join(publicDir, lightPath.replace(/\/[^/]+$/, '')), { recursive: true });
+    await writeFile(join(publicDir, lightPath), '<svg></svg>');
+    await writeFile(join(publicDir, darkPath), '<svg></svg>');
+
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'code', lang: 'mermaid', value: code }],
+    };
+
+    const file = new VFile({ path: filePath, cwd: rootDir, data: {} });
+    const transformer = (remarkMermaid as any)({ base: '/blog/' }) as any;
+    transformer(tree, file, () => {});
+
+    expect(tree.children[0].type).toBe('html');
+    const value = (tree.children[0] as any).value as string;
+    expect(value).toContain('src="/blog/generated/mermaid/notion/');
+    expect(value).toContain('.light.svg');
+    expect(value).toContain('.dark.svg');
+  });
+
+  it('keeps original code block when rendered assets are missing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'code', lang: 'mermaid', value: 'graph TD\nA-->B' }],
+    };
+    const file = new VFile({
+      path: '/tmp/src/content/blog/notion/missing.md',
+      cwd: '/tmp',
+      data: {},
+    });
+
+    const transformer = (remarkMermaid as any)({ base: '/blog/' }) as any;
+    transformer(tree, file, () => {});
+
+    expect(tree.children[0].type).toBe('code');
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/withBase.test.ts
+++ b/tests/unit/withBase.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeBase, withBase } from '../../src/lib/site/withBase';
+
+describe('withBase helpers', () => {
+  it('normalizes base values', () => {
+    expect(normalizeBase('blog')).toBe('/blog/');
+    expect(normalizeBase('/blog')).toBe('/blog/');
+    expect(normalizeBase('/')).toBe('/');
+  });
+
+  it('prefixes absolute paths with non-root base', () => {
+    expect(withBase('/generated/mermaid/a.svg', '/blog/')).toBe('/blog/generated/mermaid/a.svg');
+  });
+
+  it('keeps root base unchanged', () => {
+    expect(withBase('/generated/mermaid/a.svg', '/')).toBe('/generated/mermaid/a.svg');
+  });
+
+  it('does not double-prefix when path already contains base', () => {
+    expect(withBase('/blog/generated/mermaid/a.svg', '/blog/')).toBe(
+      '/blog/generated/mermaid/a.svg',
+    );
+  });
+
+  it('does not rewrite external or relative paths', () => {
+    expect(withBase('https://example.com/a.svg', '/blog/')).toBe('https://example.com/a.svg');
+    expect(withBase('generated/mermaid/a.svg', '/blog/')).toBe('generated/mermaid/a.svg');
+  });
+});


### PR DESCRIPTION
### Motivation
- Mermaid SVGs were sometimes rendered with site-root-relative paths (e.g. `/generated/...`) so on deployments with a non-root `base` (e.g. GitHub Pages `/blog`) the browser requested the wrong URL and images 404'd. 
- The plugin produced plain `/generated/...` URLs in the AST while Astro runtime expects `import.meta.env.BASE_URL` (site base) to be applied for absolute asset paths. 
- The site should fail open: when generated assets are missing keep the code block fallback and emit a developer-visible warning rather than introducing a broken `<img>` in HTML. 

### Description
- Added a small site base helper at `src/lib/site/withBase.ts` exposing `normalizeBase`, `withBase`, and `withBaseFromEnv` to consistently apply `import.meta.env.BASE_URL` to absolute public asset paths. 
- Updated `src/lib/markdown/remarkMermaid.ts` to accept a `base` option from `astro.config.mjs`, check that the rendered SVG files actually exist in `public/` before replacing the code block, and to write image `src` values using `withBase(...)` (so the final `<img src>` already contains the correct base prefix). 
- Hooked the plugin up in `astro.config.mjs` by passing `[remarkMermaid, { base: siteBase }]` into `markdown.remarkPlugins` so the plugin knows the configured `site` base at build time. 
- Reworked `src/lib/site/assetUrl.ts` to reuse `withBaseFromEnv` so other places that resolve asset URLs behave the same way. 
- Made CSS safety/styling changes in `src/styles/global.css` to avoid SVG images being hidden (added `overflow-x: auto`, `display:block`, `max-width:100%` on `.mermaid-dual-image` and `.mermaid-dual-image__img`). 
- Added diagnostics and failover behavior inside the remark plugin: when `process.env.DEBUG_MERMAID=1` the plugin logs absolute public path, relative public path and final `src`; when SVG files are missing the plugin `console.warn`s and leaves the original code block in the AST (fallback). 
- Added tests: unit tests for `withBase` and `remarkMermaid` plugin behavior, and an E2E test to assert that Mermaid images load (no 404) when present. 
- Files changed/added (key list): `astro.config.mjs`, `src/lib/markdown/remarkMermaid.ts`, `src/lib/site/withBase.ts` (new), `src/lib/site/assetUrl.ts`, `src/styles/global.css`, `tests/unit/withBase.test.ts`, `tests/unit/remark-mermaid.test.ts`, `tests/e2e/blog.spec.ts` (added mermaid check). 

### Testing
- Build verification: ran `npm run build` and observed that the generated files exist and are copied into `dist` as expected (evidence: `public/generated/mermaid/notion/0fec595081c3.light.svg` and `dist/generated/mermaid/notion/0fec595081c3.light.svg` were present). 
- HTML verification: inspected a built article HTML and observed the pre-fix broken `src` and the fixed `src` values; example strings discovered during investigation were `src="/generated/mermaid/notion/0fec595081c3.light.svg"` (before) and the corrected `src="/blog/generated/mermaid/notion/0fec595081c3.light.svg"` (after). 
- Server/preview verification: using `npm run preview` I validated with `curl -I` that `http://127.0.0.1:4173/generated/mermaid/...light.svg` returned `404 Not Found` while `http://127.0.0.1:4173/blog/generated/mermaid/...light.svg` returned `200 OK`, demonstrating the need for and correctness of base-prefixing. 
- Unit tests: ran `npm run test` (Vitest) and the full unit test suite passed (all tests green, including the new `withBase` and `remarkMermaid` unit tests). 
- Lint & checks: ran `npm run lint` and `npm run check` and both completed successfully. 
- E2E tests: added a Playwright test that ensures Mermaid images load without 404s; running `npm run test:e2e` in this CI environment failed due to system-level Playwright/Chromium sandbox dependencies in the runner (Chromium failed to launch / missing system libs), not due to the change itself — local preview + `curl` checks confirm the fix works in the built site. 

Notes / how the fix addresses environments
- Local dev: plugin uses `base` option supplied from `astro.config.mjs` (which is `/` in dev), so `img src` are unchanged for dev. 
- Build + preview: `siteBase` from `astro.config.mjs` is passed to the plugin and `withBase(...)` prefixes absolute public paths with the configured base (e.g. `/blog`), making `dist` pages reference the correct URL. 
- GitHub Pages: with `base='/blog'` configured in `astro.config.mjs`, built HTML now references `/blog/generated/...` and `public/generated/...` files are copied to `dist/generated/...` so assets are reachable on GitHub Pages. 
- Theme switching (dark/light): plugin still emits dual-theme `img` elements and CSS toggles visibility based on `.dark`; the CSS adjustments ensure images are visible rather than collapsed. 

If you want, I can split the PR into two (1) the path helpers + plugin update + tests and (2) the CSS/visual tweaks and e2e test, but I kept them together because they collectively resolve the broken-image symptom and add diagnostics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d161ce488321b21e2df95ee0c43f)