### PR TITLE
feat: add zoom controls to article image lightbox

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -228,10 +228,33 @@ const tocPosition = layoutConfig.toc.position;
   <img
     data-image-zoom-preview
     alt=""
-    class="max-h-[90vh] max-w-[90vw] object-contain"
+    class="max-h-[90vh] max-w-[90vw] object-contain transition-transform duration-150 ease-out"
     loading="eager"
     decoding="async"
   />
+  <div
+    class="pointer-events-none absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-black/55 px-3 py-2"
+  >
+    <div class="pointer-events-auto flex items-center gap-2 text-sm text-white">
+      <button
+        type="button"
+        data-image-zoom-out
+        class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/35 hover:bg-white/10"
+        aria-label="缩小"
+      >
+        −
+      </button>
+      <span data-image-zoom-level class="min-w-14 text-center tabular-nums">100%</span>
+      <button
+        type="button"
+        data-image-zoom-in
+        class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/35 hover:bg-white/10"
+        aria-label="放大"
+      >
+        +
+      </button>
+    </div>
+  </div>
 </dialog>
 
 <script>
@@ -239,17 +262,43 @@ const tocPosition = layoutConfig.toc.position;
   const dialog = document.querySelector('#article-image-zoom-dialog') as HTMLDialogElement | null;
   const preview = dialog?.querySelector('[data-image-zoom-preview]') as HTMLImageElement | null;
   const closeButton = dialog?.querySelector('[data-image-zoom-close]') as HTMLButtonElement | null;
+  const zoomInButton = dialog?.querySelector('[data-image-zoom-in]') as HTMLButtonElement | null;
+  const zoomOutButton = dialog?.querySelector('[data-image-zoom-out]') as HTMLButtonElement | null;
+  const zoomLevelLabel = dialog?.querySelector('[data-image-zoom-level]') as HTMLSpanElement | null;
 
   if (articleRoot && dialog && preview && typeof dialog.showModal === 'function') {
     const zoomableImages = Array.from(articleRoot.querySelectorAll('img')).filter(
       (img) => !img.closest('[data-post-cover]'),
     );
+    const MIN_ZOOM = 1;
+    const MAX_ZOOM = 4;
+    const ZOOM_STEP = 0.25;
+    let zoomLevel = 1;
+
+    const renderZoomLevel = () => {
+      preview.style.transform = `scale(${zoomLevel})`;
+      if (zoomLevelLabel) {
+        zoomLevelLabel.textContent = `${Math.round(zoomLevel * 100)}%`;
+      }
+      if (zoomOutButton) {
+        zoomOutButton.disabled = zoomLevel <= MIN_ZOOM;
+      }
+      if (zoomInButton) {
+        zoomInButton.disabled = zoomLevel >= MAX_ZOOM;
+      }
+    };
+
+    const setZoomLevel = (nextZoomLevel: number) => {
+      zoomLevel = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, nextZoomLevel));
+      renderZoomLevel();
+    };
 
     const closeDialog = () => {
       if (!dialog.open) return;
       dialog.close();
       preview.removeAttribute('src');
       preview.alt = '';
+      setZoomLevel(1);
     };
 
     zoomableImages.forEach((img) => {
@@ -262,6 +311,7 @@ const tocPosition = layoutConfig.toc.position;
         if (!source) return;
         preview.src = source;
         preview.alt = img.alt || '文章图片预览';
+        setZoomLevel(1);
         dialog.showModal();
       };
 
@@ -275,14 +325,43 @@ const tocPosition = layoutConfig.toc.position;
     });
 
     closeButton?.addEventListener('click', closeDialog);
+    zoomInButton?.addEventListener('click', () => {
+      setZoomLevel(zoomLevel + ZOOM_STEP);
+    });
+    zoomOutButton?.addEventListener('click', () => {
+      setZoomLevel(zoomLevel - ZOOM_STEP);
+    });
+    preview.addEventListener('wheel', (event) => {
+      event.preventDefault();
+      const direction = event.deltaY < 0 ? 1 : -1;
+      setZoomLevel(zoomLevel + direction * ZOOM_STEP);
+    });
     dialog.addEventListener('click', (event) => {
       if (event.target === dialog) {
         closeDialog();
       }
     });
+    dialog.addEventListener('keydown', (event) => {
+      if (!dialog.open) return;
+      if (event.key === '+' || event.key === '=') {
+        event.preventDefault();
+        setZoomLevel(zoomLevel + ZOOM_STEP);
+      }
+      if (event.key === '-' || event.key === '_') {
+        event.preventDefault();
+        setZoomLevel(zoomLevel - ZOOM_STEP);
+      }
+      if (event.key === '0') {
+        event.preventDefault();
+        setZoomLevel(1);
+      }
+    });
     dialog.addEventListener('cancel', () => {
       preview.removeAttribute('src');
       preview.alt = '';
+      setZoomLevel(1);
     });
+
+    renderZoomLevel();
   }
 </script>


### PR DESCRIPTION
### Motivation
- Allow users to further zoom and inspect images after opening the article image lightbox to improve readability and UX.
- Provide multiple interaction modes (buttons, mouse wheel, keyboard) so users can zoom in the way they prefer.

### Description
- Added a bottom overlay in the image preview dialog containing `-` and `+` buttons and a live zoom percentage label, and added a smooth transform transition to the preview image (`src/pages/[...slug].astro`).
- Implemented zoom state management with `MIN_ZOOM`, `MAX_ZOOM`, and `ZOOM_STEP`, and exposed `setZoomLevel` / `renderZoomLevel` helpers to apply `scale()` to the preview and update UI state (`src/pages/[...slug].astro`).
- Wired up interactions: click handlers for `data-image-zoom-in` / `data-image-zoom-out`, mouse wheel zoom on the preview, keyboard shortcuts (`+`, `-`, `0` reset), and reset zoom when opening/closing/canceling the dialog (`src/pages/[...slug].astro`).

### Testing
- Ran `npm run format:check` (Prettier) which passed after formatting the updated file.
- Ran `npm run check` (Astro type/content check) which completed with `0 errors` and no blocking issues.
- Launched the dev server and executed a headless Playwright script that opened an article, triggered the image lightbox, exercised the zoom controls, and saved a screenshot (`artifacts/image-zoom-dialog.png`) to verify behavior; the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d9ebc6208321a585d030842d1a11)