### PR TITLE
feat: decouple image zoom dialog from page scroll and add double-click zoom toggle

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -273,26 +273,8 @@ const tocPosition = layoutConfig.toc.position;
     const MIN_ZOOM = 1;
     const MAX_ZOOM = 4;
     const ZOOM_STEP = 0.25;
+    const DOUBLE_CLICK_ZOOM = 2;
     let zoomLevel = 1;
-    let scrollY = 0;
-
-    const lockBackgroundScroll = () => {
-      scrollY = window.scrollY;
-      document.documentElement.style.overscrollBehavior = 'none';
-      document.body.style.position = 'fixed';
-      document.body.style.top = `-${scrollY}px`;
-      document.body.style.width = '100%';
-      document.body.style.overflow = 'hidden';
-    };
-
-    const unlockBackgroundScroll = () => {
-      document.documentElement.style.removeProperty('overscroll-behavior');
-      document.body.style.removeProperty('position');
-      document.body.style.removeProperty('top');
-      document.body.style.removeProperty('width');
-      document.body.style.removeProperty('overflow');
-      window.scrollTo(0, scrollY);
-    };
 
     const renderZoomLevel = () => {
       preview.style.transform = `scale(${zoomLevel})`;
@@ -315,7 +297,6 @@ const tocPosition = layoutConfig.toc.position;
     const closeDialog = () => {
       if (!dialog.open) return;
       dialog.close();
-      unlockBackgroundScroll();
       preview.removeAttribute('src');
       preview.alt = '';
       setZoomLevel(1);
@@ -332,7 +313,6 @@ const tocPosition = layoutConfig.toc.position;
         preview.src = source;
         preview.alt = img.alt || '文章图片预览';
         setZoomLevel(1);
-        lockBackgroundScroll();
         dialog.showModal();
       };
 
@@ -357,6 +337,10 @@ const tocPosition = layoutConfig.toc.position;
       const direction = event.deltaY < 0 ? 1 : -1;
       setZoomLevel(zoomLevel + direction * ZOOM_STEP);
     });
+    preview.addEventListener('dblclick', (event) => {
+      event.preventDefault();
+      setZoomLevel(zoomLevel > MIN_ZOOM ? MIN_ZOOM : DOUBLE_CLICK_ZOOM);
+    });
     dialog.addEventListener('click', (event) => {
       if (event.target === dialog) {
         closeDialog();
@@ -378,7 +362,6 @@ const tocPosition = layoutConfig.toc.position;
       }
     });
     dialog.addEventListener('cancel', () => {
-      unlockBackgroundScroll();
       preview.removeAttribute('src');
       preview.alt = '';
       setZoomLevel(1);


### PR DESCRIPTION
### Motivation
- Enable double-click to toggle image preview zoom and simplify user interaction in the zoom overlay.
- Remove the overlay behavior that recorded/restored the page `scrollY` to make the zoom dialog lifecycle independent from the main page scrolling state.

### Description
- Updated `src/pages/[...slug].astro` to remove background scroll-locking and `scrollY` restore logic by deleting `lockBackgroundScroll`/`unlockBackgroundScroll` and related state and calls.
- Added a `DOUBLE_CLICK_ZOOM` constant and a `dblclick` handler on the preview image to toggle between `100%` and `200%` zoom while leaving the existing wheel/button/keyboard zoom behavior intact.
- Kept the dialog lifecycle self-contained by ensuring the preview `src`/`alt` are cleared on close/cancel and resetting `zoomLevel` to `1`.

### Testing
- Ran `npm run check`, which completed with no errors and no warnings affecting the change.
- Launched the dev server with `npm run dev` and validated the feature via a Playwright script that opened an article, clicked an image to open the zoom dialog, double-clicked the preview to toggle zoom, and captured a screenshot; the automated interaction succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e2c2cd4883219dc629cfae6c0026)