### PR TITLE
Fix sticky drag behavior in zoomed image preview

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -226,6 +226,7 @@ const tocPosition = layoutConfig.toc.position;
   <img
     data-image-zoom-preview
     alt=""
+    draggable="false"
     class="max-h-[90vh] max-w-[90vw] touch-none select-none rounded-lg bg-zinc-100 p-2 object-contain shadow-2xl transition-transform duration-150 ease-out will-change-transform dark:bg-zinc-800"
     loading="eager"
     decoding="async"
@@ -446,6 +447,9 @@ const tocPosition = layoutConfig.toc.position;
         event.clientX,
         event.clientY,
       );
+    });
+    preview.addEventListener('dragstart', (event) => {
+      event.preventDefault();
     });
     preview.addEventListener('pointerdown', (event) => {
       if (!dialog.open) return;


### PR DESCRIPTION
## Summary
- disable native browser drag on the zoom preview image (`draggable="false"`)
- prevent `dragstart` in the image preview script so pointer-based panning stays smooth

## Why
When the image is opened in the dialog, native image dragging can compete with pointer move events, which feels like the image is being "pulled" or hard to drag.

## Files changed
- `src/pages/[...slug].astro`

## Validation
- Static inspection only (no runtime tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6fab485cc8321a74a252a25813868)