### PR TITLE
style: move post share button below tag row

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -133,7 +133,7 @@ const tocPosition = layoutConfig.toc.position;
                 </div>
               </div>
 
-              <div class="flex flex-wrap items-center gap-2" data-testid="post-share-tags-row">
+              <div class="flex flex-col items-start gap-2" data-testid="post-share-tags-row">
                 {
                   tagSlugs.length > 0 && (
                     <div class="flex flex-wrap gap-2 items-center" data-testid="post-tags">


### PR DESCRIPTION
### Motivation
- Ensure the post "分享" (share) button appears on its own line under the tag chips to improve visual grouping and avoid layout crowding on article pages.

### Description
- Replace the tags/share container's layout in `src/pages/[...slug].astro` from `flex flex-wrap items-center gap-2` to `flex flex-col items-start gap-2`, so the share button renders on the next line beneath the tag chips; no JS/logic changes were made.

### Testing
- Ran the repository quality gates: `npm run check`, `npm run lint`, `npm run format`, and `npm run test` which all completed successfully; `npm run test:e2e` ran and reported one unrelated/flaky failure in an existing mobile TOC test, and `npm run ci` was executed but observed noisy build-time diagnostics from generated `dist/_astro` files without code issues related to this layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a845272d1c83218eb342acccab3487)