### PR TITLE
优化文章页分享入口：图标与文字分离并采用标签样式可点击

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -147,16 +147,18 @@ const tocPosition = layoutConfig.toc.position;
                     </div>
                   )
                 }
-                <button
-                  type="button"
-                  class="inline-flex items-center gap-1 rounded-full border border-zinc-300 px-2 py-0.5 text-xs font-medium text-zinc-600 transition hover:border-zinc-400 hover:bg-zinc-100 hover:text-zinc-800 dark:border-zinc-700 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
-                  data-share-open
-                  aria-haspopup="dialog"
-                  aria-controls="article-share-dialog"
-                >
-                  <span aria-hidden="true">🔗</span>
-                  分享
-                </button>
+                <div class="inline-flex items-center gap-2" data-testid="post-share-action">
+                  <span class="text-zinc-500 text-sm" aria-hidden="true"> 🔗 </span>
+                  <button
+                    type="button"
+                    class="inline-flex items-center rounded-full border border-sky-200 bg-sky-50 px-2 py-1 text-xs font-medium text-sky-700 transition-colors duration-200 hover:border-sky-300 hover:bg-sky-100 dark:border-sky-900 dark:bg-sky-950 dark:text-sky-300 dark:hover:border-sky-700 dark:hover:bg-sky-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-zinc-900"
+                    data-share-open
+                    aria-haspopup="dialog"
+                    aria-controls="article-share-dialog"
+                  >
+                    分享
+                  </button>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
### Motivation
- 将文章详情页的分享入口视觉与交互优化为图标单独展示、文字可点击，从而与标签 chip 的交互风格一致并提升可访问性。 

### Description
- 在 `src/pages/[...slug].astro` 中将原先的带图标按钮拆分为一个独立图标 `span` 与一个可点击的分享 `button`（使用与标签一致的 chip 风格类名，包含浅色/暗色、hover 与 `focus-visible` 状态）。

### Testing
- 在仓内执行过 `npm run check`、`npm run lint`、`npm run format` 和 `npm run test`，以上均通过；`npm run test:e2e` 与 `npm run ci` 在本次运行中因仓库已有的 e2e 用例 `tests/e2e/blog.spec.ts:299` 失败而未全部通过，该失败为仓内现有 flaky 用例，与本次分享入口的小范围样式改动无关。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8485c3be48321823341f82137b620)