### PR TITLE
Fix image lightbox close scroll restoration jump

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -375,6 +375,9 @@ const tocPosition = layoutConfig.toc.position;
 
   const unlockBodyScroll = () => {
     if (document.body.dataset.scrollLock !== 'true') return;
+    const html = document.documentElement;
+    const previousScrollBehavior = html.style.scrollBehavior;
+    html.style.scrollBehavior = 'auto';
     document.body.style.position = '';
     document.body.style.top = '';
     document.body.style.left = '';
@@ -382,7 +385,8 @@ const tocPosition = layoutConfig.toc.position;
     document.body.style.width = '';
     document.body.style.overflow = '';
     delete document.body.dataset.scrollLock;
-    window.scrollTo(0, lockedScrollY);
+    window.scrollTo({ top: lockedScrollY, left: 0, behavior: 'auto' });
+    html.style.scrollBehavior = previousScrollBehavior;
   };
 
   if (shareMarkdownText) {


### PR DESCRIPTION
### Motivation
- Prevent the main page from visibly sliding from top when closing the image/share dialog by ensuring the stored scroll position is restored without triggering any smooth-scroll animation in `unlockBodyScroll` (`src/pages/[...slug].astro`).

### Description
- Temporarily set `document.documentElement.style.scrollBehavior = 'auto'` inside `unlockBodyScroll`, call `window.scrollTo({ top: lockedScrollY, left: 0, behavior: 'auto' })`, then restore the previous inline `scrollBehavior` to avoid the smooth-slide effect; change is confined to `src/pages/[...slug].astro` in `unlockBodyScroll`.

### Testing
- Ran `npm run check`, `npm run lint`, `npm run format`, `npm run test`, and `npm run test:e2e`, all completed successfully in this environment; `npm run ci` failed due to an external apt mirror (`502` during `playwright install --with-deps`) and is unrelated to the code change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9368f988883218c491edacdbf496a)