### PR TITLE
优化文章 slug 生成策略并引入全站唯一性校验

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "katex": "^0.16.27",
         "mermaid": "^11.12.3",
         "notion-to-md": "^3.1.9",
+        "pinyin-pro": "^3.28.0",
         "rehype-katex": "^7.0.1",
         "rehype-parse": "^9.0.1",
         "rehype-raw": "^7.0.0",
@@ -7895,6 +7896,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/pinyin-pro": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.28.0.tgz",
+      "integrity": "sha512-mMRty6RisoyYNphJrTo3pnvp3w8OMZBrXm9YSWkxhAfxKj1KZk2y8T2PDIZlDDRsvZ0No+Hz6FI4sZpA6Ey25g==",
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "katex": "^0.16.27",
     "mermaid": "^11.12.3",
     "notion-to-md": "^3.1.9",
+    "pinyin-pro": "^3.28.0",
     "rehype-katex": "^7.0.1",
     "rehype-parse": "^9.0.1",
     "rehype-raw": "^7.0.0",

--- a/scripts/content-import.ts
+++ b/scripts/content-import.ts
@@ -17,11 +17,12 @@ import sharp from 'sharp';
 import { JSDOM } from 'jsdom';
 import readline from 'readline';
 import { BLOG_CONTENT_DIR, PUBLIC_IMAGES_DIR } from '../src/config/paths';
-import { slugFromTitle } from '../src/lib/slug';
+import { ensureUniqueSlug, slugFromTitle } from '../src/lib/slug';
 import { processMarkdownForImport } from './markdown/index.js';
 import { resolveAdapter } from './import/adapters/index.js';
 import { createScriptLogger, now, duration } from './logger-helpers.js';
 import { redactValue } from './logger/redaction.js';
+import { buildSlugOwnerMap } from './slug-registry.js';
 
 dotenv.config({ path: '.env.local' });
 
@@ -1329,13 +1330,16 @@ async function main() {
       throw error;
     }
 
-    // Phase 2: Generate final slug from article title
-    const slug = slugFromTitle({
+    // Phase 2: Generate final slug from article title and ensure global uniqueness
+    const baseSlug = slugFromTitle({
       title: article.title,
       fallbackId: fallbackSlug,
     });
+    const usedSlugs = buildSlugOwnerMap(CONTENT_ROOT);
+    const ownerId = `import:${adapter.id}:${targetUrl}`;
+    const slug = ensureUniqueSlug(baseSlug, ownerId, usedSlugs);
 
-    logger.info('Generated slug', { tempSlug, finalSlug: slug, title: article.title });
+    logger.info('Generated slug', { tempSlug, baseSlug, finalSlug: slug, title: article.title });
 
     // Phase 3: Handle slug migration if tempSlug != finalSlug
     // This ensures image directory and references are consistent with final slug

--- a/scripts/notion-sync.ts
+++ b/scripts/notion-sync.ts
@@ -11,6 +11,7 @@ import { slugFromTitle, ensureUniqueSlug } from '../src/lib/slug';
 import { NOTION_CONTENT_DIR, NOTION_PUBLIC_IMG_DIR, ensureDir } from '../src/config/paths';
 import { processMarkdownForImport } from './markdown/index.js';
 import { createScriptLogger, now, duration } from './logger-helpers.js';
+import { buildSlugOwnerMap } from './slug-registry.js';
 
 dotenv.config({ path: '.env.local' });
 
@@ -259,7 +260,7 @@ export async function sync() {
 
   try {
     const existingPosts = await getExistingPosts();
-    const usedSlugs = new Map<string, string>();
+    const usedSlugs = buildSlugOwnerMap(path.dirname(NOTION_CONTENT_DIR));
     for (const [slug, meta] of existingPosts.bySlug.entries()) {
       usedSlugs.set(slug, meta.notionId ?? `existing-${slug}`);
     }

--- a/scripts/slug-registry.ts
+++ b/scripts/slug-registry.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+function walkMarkdownFiles(dir: string, files: string[] = []): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkMarkdownFiles(fullPath, files);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Build slug ownership map from all blog markdown files.
+ * slug -> ownerId
+ */
+export function buildSlugOwnerMap(contentRoot: string): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!fs.existsSync(contentRoot)) return map;
+
+  const files = walkMarkdownFiles(contentRoot);
+  for (const file of files) {
+    const raw = fs.readFileSync(file, 'utf-8');
+    const { data } = matter(raw);
+    const slug = String(data.slug || path.basename(file, '.md')).trim();
+    if (!slug) continue;
+
+    const notionId = data?.notion?.id || data.notionId;
+    const ownerId = notionId ? String(notionId) : `file:${path.relative(contentRoot, file)}`;
+    if (!map.has(slug)) {
+      map.set(slug, ownerId);
+    }
+  }
+
+  return map;
+}

--- a/src/lib/slug/index.ts
+++ b/src/lib/slug/index.ts
@@ -10,6 +10,7 @@
 
 import crypto from 'crypto';
 import slugify from 'slugify';
+import { pinyin } from 'pinyin-pro';
 import { siteBase } from '../../config/site';
 
 /**
@@ -33,6 +34,25 @@ import { siteBase } from '../../config/site';
 export function normalizeSlug(value: string): string {
   if (!value) return '';
   return slugify(value, { lower: true, strict: true }) || '';
+}
+
+/**
+ * Convert mixed-language title into a latin slug candidate.
+ *
+ * Strategy:
+ * 1. Try direct normalization first (handles English and symbols)
+ * 2. If empty, romanize CJK with pinyin and normalize again
+ */
+export function toLatinSlug(value: string): string {
+  const normalized = normalizeSlug(value);
+  if (normalized) return normalized;
+
+  const romanized = pinyin(value, { toneType: 'none', type: 'array', nonZh: 'consecutive' })
+    .map((chunk) => String(chunk).trim())
+    .filter(Boolean)
+    .join(' ');
+
+  return normalizeSlug(romanized);
 }
 
 /**
@@ -63,7 +83,7 @@ export function slugFromTitle(options: {
   if (explicit) return explicit;
 
   // Priority 2: Title
-  const fromTitle = title ? normalizeSlug(title) : '';
+  const fromTitle = title ? toLatinSlug(title) : '';
   if (fromTitle) return fromTitle;
 
   // Priority 3: Fallback ID

--- a/tests/unit/slug-consolidated.test.ts
+++ b/tests/unit/slug-consolidated.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   normalizeSlug,
+  toLatinSlug,
   slugFromTitle,
   slugFromFileStem,
   shortHash,
@@ -74,6 +75,10 @@ describe('normalizeSlug', () => {
 });
 
 describe('slugFromTitle', () => {
+  it('romanizes Chinese titles before fallback', () => {
+    expect(slugFromTitle({ title: '你好世界', fallbackId: 'page-123' })).toBe('ni-hao-shi-jie');
+  });
+
   it('uses explicit slug if provided', () => {
     expect(
       slugFromTitle({
@@ -358,15 +363,15 @@ describe('Edge Cases and Integration', () => {
   });
 
   it('handles Chinese-only titles with fallback', () => {
-    // Pure Chinese title falls back to ID
+    // Pure Chinese title is romanized first
     const slug = slugFromTitle({
       title: '你好世界',
       fallbackId: 'page-123',
     });
-    expect(slug).toBe('page-123');
+    expect(slug).toBe('ni-hao-shi-jie');
 
     const url = buildPostUrl(slug, '/blog/');
-    expect(url).toBe('/blog/page-123/');
+    expect(url).toBe('/blog/ni-hao-shi-jie/');
   });
 
   it('handles Notion-style workflow with conflicts', () => {
@@ -411,5 +416,15 @@ describe('Edge Cases and Integration', () => {
 
     const url = buildPostUrl(slug, '/blog/');
     expect(url).toBe('/blog/hello-world/');
+  });
+});
+
+describe('toLatinSlug', () => {
+  it('keeps english title unchanged after normalization', () => {
+    expect(toLatinSlug('Hello World')).toBe('hello-world');
+  });
+
+  it('romanizes chinese text to a latin slug', () => {
+    expect(toLatinSlug('优化生成机制')).toBe('you-hua-sheng-cheng-ji-zhi');
   });
 });

--- a/tests/unit/slug-registry.test.ts
+++ b/tests/unit/slug-registry.test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildSlugOwnerMap } from '../../scripts/slug-registry.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe('buildSlugOwnerMap', () => {
+  it('collects slugs from nested markdown files', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'slug-map-'));
+    tempDirs.push(root);
+    fs.mkdirSync(path.join(root, 'notion'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'wechat'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(root, 'notion', 'a.md'),
+      `---\nslug: custom-slug\nnotion:\n  id: notion-123\n---\ncontent`,
+    );
+    fs.writeFileSync(path.join(root, 'wechat', 'b.md'), `---\ntitle: test\n---\ncontent`);
+
+    const map = buildSlugOwnerMap(root);
+    expect(map.get('custom-slug')).toBe('notion-123');
+    expect(map.get('b')).toBe('file:wechat/b.md');
+  });
+});

--- a/tests/unit/slug.test.ts
+++ b/tests/unit/slug.test.ts
@@ -22,6 +22,14 @@ describe('slug utilities', () => {
     expect(
       deriveSlug({
         explicitSlug: '',
+        title: '你好世界',
+        fallbackId: '123',
+      }),
+    ).toBe('ni-hao-shi-jie');
+
+    expect(
+      deriveSlug({
+        explicitSlug: '',
         title: '',
         fallbackId: '123',
       }),


### PR DESCRIPTION
### Motivation
- 解决中文标题生成 slug 时常被清空回退到 fallbackId 的可读性问题，并避免不同内容来源（notion/wechat/others）间的 slug 冲突。 
- 保持 Scripts 层对 Runtime 层 `src/lib/slug` 的单一入口约定，强化在导入/同步流程中生成全站唯一 slug 的能力。 

### Description
- 在 `src/lib/slug/index.ts` 中新增 `toLatinSlug` 并将 `slugFromTitle` 改为优先使用该函数以支持中文转拼音后归一化（新增依赖 `pinyin-pro`）。
- 新增脚本 `scripts/slug-registry.ts`，递归扫描 `src/content/blog` 下所有 Markdown 文件并构建 `slug -> ownerId` 的占用表用于全站去重。 
- 在 `scripts/content-import.ts` 中：生成 `baseSlug` 后加载全站占用表并通过 `ensureUniqueSlug(baseSlug, ownerId, usedSlugs)` 生成最终 slug，保留原有 image 目录迁移逻辑以保证引用一致性。 
- 在 `scripts/notion-sync.ts` 中：初始化 `usedSlugs` 时切换为全站扫描结果以避免 Notion 同步的 slug 与其它来源冲突。 
- 新增/更新单元测试以覆盖中文标题拉丁化、slug 注册表扫描与兼容性回归：`tests/unit/slug.test.ts`、`tests/unit/slug-consolidated.test.ts`、`tests/unit/slug-registry.test.ts`。 

### Testing
- Ran `npm run check`, `npm run format`, and `npm run lint`, all completed successfully. 
- Ran unit tests with `npm run test` (including the updated slug tests and the new `slug-registry` test), all unit tests passed. 
- Ran E2E with `npm run test:e2e` and observed one unrelated flaky failure: `mobile toc navigates to heading` (hash navigation / viewport Y offset exceeded threshold). 
- Ran full `npm run ci` which exercised build and e2e flow but encountered Node OOM in this environment (memory during large build/e2e run); the unit/test-suite steps themselves passed prior to that OOM.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc9bf47088321bb1a26258713c9ab)