### PR TITLE
feat: add Modern GPU Programming column and fix CI

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -33,4 +33,8 @@ skip_missing = true
 # ---------- 忽略噪声目录 ----------
 exclude_path = [
   "node_modules",
+  # These Markdown files use Astro route-relative links (for example,
+  # ../05-training/) rather than source-tree-relative file links. Their
+  # navigation and assets are covered by the build and book E2E suite.
+  "(^|/)src/content/scalingBook/",
 ]

--- a/public/images/columns/modern-gpu-programming-for-mlsys.svg
+++ b/public/images/columns/modern-gpu-programming-for-mlsys.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title description">
+  <title id="title">Modern GPU Programming For MLSys</title>
+  <desc id="description">An abstract GPU composed of compute tiles, data paths, and a tensor core grid.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#07111f" />
+      <stop offset="0.52" stop-color="#0b2740" />
+      <stop offset="1" stop-color="#14395a" />
+    </linearGradient>
+    <linearGradient id="signal" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#38bdf8" />
+      <stop offset="1" stop-color="#a78bfa" />
+    </linearGradient>
+    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#22d3ee" stop-opacity="0.95" />
+      <stop offset="1" stop-color="#6366f1" stop-opacity="0.8" />
+    </linearGradient>
+    <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">
+      <path d="M 32 0 L 0 0 0 32" fill="none" stroke="#7dd3fc" stroke-opacity="0.1" stroke-width="1" />
+    </pattern>
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="10" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="675" fill="url(#background)" />
+  <rect width="1200" height="675" fill="url(#grid)" />
+  <circle cx="1070" cy="-30" r="330" fill="#0ea5e9" opacity="0.08" />
+  <circle cx="980" cy="650" r="280" fill="#8b5cf6" opacity="0.1" />
+
+  <g transform="translate(74 92)">
+    <rect x="0" y="0" width="602" height="491" rx="36" fill="#071725" stroke="#38bdf8" stroke-opacity="0.3" stroke-width="2" />
+    <rect x="30" y="30" width="542" height="431" rx="24" fill="#0b2134" stroke="#7dd3fc" stroke-opacity="0.18" />
+
+    <g fill="#0f334c" stroke="#38bdf8" stroke-opacity="0.38">
+      <rect x="58" y="62" width="132" height="88" rx="13" />
+      <rect x="206" y="62" width="132" height="88" rx="13" />
+      <rect x="354" y="62" width="160" height="88" rx="13" />
+      <rect x="58" y="166" width="132" height="88" rx="13" />
+      <rect x="206" y="166" width="308" height="88" rx="13" />
+      <rect x="58" y="270" width="280" height="158" rx="13" />
+      <rect x="354" y="270" width="160" height="158" rx="13" />
+    </g>
+
+    <g fill="url(#tile)" opacity="0.95">
+      <rect x="78" y="82" width="22" height="22" rx="4" />
+      <rect x="112" y="82" width="22" height="22" rx="4" />
+      <rect x="146" y="82" width="22" height="22" rx="4" />
+      <rect x="226" y="82" width="92" height="12" rx="6" />
+      <rect x="226" y="108" width="66" height="12" rx="6" opacity="0.65" />
+      <rect x="374" y="82" width="120" height="12" rx="6" />
+      <rect x="374" y="108" width="82" height="12" rx="6" opacity="0.65" />
+      <rect x="78" y="186" width="92" height="12" rx="6" />
+      <rect x="78" y="212" width="62" height="12" rx="6" opacity="0.65" />
+    </g>
+
+    <g transform="translate(228 188)">
+      <g fill="#22d3ee" opacity="0.86">
+        <rect x="0" y="0" width="32" height="32" rx="5" />
+        <rect x="44" y="0" width="32" height="32" rx="5" opacity="0.72" />
+        <rect x="88" y="0" width="32" height="32" rx="5" opacity="0.58" />
+        <rect x="132" y="0" width="32" height="32" rx="5" opacity="0.45" />
+        <rect x="176" y="0" width="32" height="32" rx="5" opacity="0.32" />
+        <rect x="220" y="0" width="32" height="32" rx="5" opacity="0.2" />
+      </g>
+    </g>
+
+    <g transform="translate(82 294)" fill="none" stroke="url(#signal)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" filter="url(#glow)">
+      <path d="M0 97 H52 L82 38 L126 126 L166 74 H224" />
+      <circle cx="0" cy="97" r="7" fill="#38bdf8" stroke="none" />
+      <circle cx="224" cy="74" r="7" fill="#a78bfa" stroke="none" />
+    </g>
+
+    <g transform="translate(378 294)" fill="#7dd3fc">
+      <rect x="0" y="0" width="28" height="28" rx="5" opacity="0.95" />
+      <rect x="38" y="0" width="28" height="28" rx="5" opacity="0.72" />
+      <rect x="76" y="0" width="28" height="28" rx="5" opacity="0.48" />
+      <rect x="0" y="38" width="28" height="28" rx="5" opacity="0.72" />
+      <rect x="38" y="38" width="28" height="28" rx="5" opacity="0.95" />
+      <rect x="76" y="38" width="28" height="28" rx="5" opacity="0.72" />
+      <rect x="0" y="76" width="28" height="28" rx="5" opacity="0.48" />
+      <rect x="38" y="76" width="28" height="28" rx="5" opacity="0.72" />
+      <rect x="76" y="76" width="28" height="28" rx="5" opacity="0.95" />
+    </g>
+
+    <path d="M-24 92 H0 M-24 196 H0 M-24 350 H0 M602 124 H626 M602 246 H626 M602 402 H626" stroke="url(#signal)" stroke-width="8" stroke-linecap="round" />
+  </g>
+
+  <g transform="translate(728 132)" fill="#f8fafc">
+    <text x="0" y="0" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="700" letter-spacing="5" fill="#7dd3fc">MODERN</text>
+    <text x="0" y="80" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="72" font-weight="800" letter-spacing="-3">GPU</text>
+    <text x="0" y="144" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="54" font-weight="750" letter-spacing="-2">PROGRAMMING</text>
+    <rect x="0" y="178" width="350" height="4" rx="2" fill="url(#signal)" />
+    <text x="0" y="235" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="28" font-weight="650" letter-spacing="4" fill="#cbd5e1">FOR MLSYS</text>
+    <text x="0" y="330" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600" letter-spacing="2" fill="#94a3b8">BLACKWELL  ·  TIRx</text>
+    <text x="0" y="366" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="18" font-weight="600" letter-spacing="2" fill="#94a3b8">GEMM  ·  ATTENTION</text>
+  </g>
+</svg>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -38,6 +38,7 @@ function isMenuItemActive(item: { href: string; isExternal: boolean }): boolean 
 
   if (item.href === COLUMNS_INDEX_PATH) {
     const isColumnRoute = COLUMN_CATALOG.some((column) => {
+      if (column.isExternal) return false;
       const columnPath = `${BASE}${column.href.slice(1)}`;
       const normalizedColumn = columnPath.endsWith('/') ? columnPath : `${columnPath}/`;
       return normalizedCurrent.startsWith(normalizedColumn);
@@ -56,7 +57,7 @@ function isMenuItemActive(item: { href: string; isExternal: boolean }): boolean 
   >
     <a
       href={BASE}
-      class="text-xl font-bold hover:text-sky-600 dark:hover:text-sky-400 flex items-center gap-2"
+      class="text-xl font-bold hover:text-sky-600 dark:hover:text-sky-400 flex shrink-0 items-center gap-2"
     >
       {
         navConfig.header.brandLogo && (
@@ -71,7 +72,7 @@ function isMenuItemActive(item: { href: string; isExternal: boolean }): boolean 
       }
       <span class="hidden sm:inline">{navConfig.header.brandText}</span>
     </a>
-    <nav class={`flex ${itemsClass} gap-2 sm:gap-3 items-center`}>
+    <nav class={`flex ${itemsClass} items-center gap-1 text-sm sm:gap-3 sm:text-base`}>
       {
         navConfig.header.menuItems.map((item) => {
           const isActive = isMenuItemActive(item);
@@ -142,7 +143,10 @@ function isMenuItemActive(item: { href: string; isExternal: boolean }): boolean 
     iconSpan.style.lineHeight = '1';
     iconSpan.textContent = icon;
     button.appendChild(iconSpan);
-    button.appendChild(document.createTextNode(' ' + label));
+    const labelSpan = document.createElement('span');
+    labelSpan.className = 'hidden sm:inline';
+    labelSpan.textContent = label;
+    button.appendChild(labelSpan);
     button.setAttribute('aria-label', `Toggle theme (current: ${label})`);
   };
 

--- a/src/components/columns/ColumnCard.astro
+++ b/src/components/columns/ColumnCard.astro
@@ -8,13 +8,15 @@ interface Props {
 
 const { column } = Astro.props;
 const BASE = normalizeBase(import.meta.env.BASE_URL);
-const columnUrl = `${BASE}${column.href.slice(1)}`;
+const columnUrl = column.isExternal ? column.href : `${BASE}${column.href.slice(1)}`;
 const coverUrl = `${BASE}${column.coverImage.slice(1)}`;
 ---
 
 <article data-column-card data-column-slug={column.slug}>
   <a
     href={columnUrl}
+    target={column.isExternal ? '_blank' : undefined}
+    rel={column.isExternal ? 'noopener noreferrer' : undefined}
     class="group grid overflow-hidden rounded-3xl border border-zinc-200 bg-neutral-50/75 shadow-md transition duration-200 hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900/55 dark:hover:border-sky-600 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]"
   >
     <div class="p-6 sm:p-8">
@@ -52,7 +54,9 @@ const coverUrl = `${BASE}${column.coverImage.slice(1)}`;
       </ul>
 
       <div class="mt-7 flex justify-end">
-        <span class="text-sm font-semibold text-sky-700 dark:text-sky-300">进入专栏 →</span>
+        <span class="text-sm font-semibold text-sky-700 dark:text-sky-300">
+          {column.isExternal ? '访问官方专栏 ↗' : '进入专栏 →'}
+        </span>
       </div>
     </div>
 

--- a/src/config/yaml/layout.yml
+++ b/src/config/yaml/layout.yml
@@ -60,6 +60,9 @@ commonLinks:
       href: 'https://lmsys.org/blog/'
       description: 'AI Infra 系列博客'
       newTab: true
+    - label: 'How to Scale Your Model'
+      href: 'https://jax-ml.github.io/scaling-book/'
+      description: 'A Systems View of LLMs on TPUs'
     - label: 'Modern GPU Programming For MLSys'
       href: 'https://mlc.ai/modern-gpu-programming-for-mlsys/zh/index.html'
       description: '面向机器学习系统的现代 GPU 编程'

--- a/src/lib/content/columns.ts
+++ b/src/lib/content/columns.ts
@@ -1,10 +1,12 @@
 import { SCALING_BOOK_SHORT_TITLE, SCALING_BOOK_TITLE } from './scalingBookMeta';
 
 export const COLUMNS_INDEX_PATH = '/columns/';
+export const MODERN_GPU_PROGRAMMING_ZH_URL = 'https://mlc.ai/modern-gpu-programming-for-mlsys/zh/';
 
 export interface ColumnDefinition {
   slug: string;
-  href: `/${string}/`;
+  href: `/${string}/` | `https://${string}`;
+  isExternal: boolean;
   eyebrow: string;
   title: string;
   shortTitle: string;
@@ -25,6 +27,7 @@ export const COLUMN_CATALOG = [
   {
     slug: 'scaling-book',
     href: '/scaling-book/',
+    isExternal: false,
     eyebrow: '大模型系统 · 完整译著',
     title: SCALING_BOOK_TITLE,
     shortTitle: SCALING_BOOK_SHORT_TITLE,
@@ -36,6 +39,22 @@ export const COLUMN_CATALOG = [
     coverWidth: 1784,
     coverHeight: 631,
     topics: ['LLM 系统', 'TPU', 'GPU', '训练与推理'],
+  },
+  {
+    slug: 'modern-gpu-programming-for-mlsys',
+    href: MODERN_GPU_PROGRAMMING_ZH_URL,
+    isExternal: true,
+    eyebrow: 'MLC Community · 官方教程',
+    title: '面向机器学习系统的现代 GPU 编程',
+    shortTitle: 'Modern GPU Programming For MLSys 中文版',
+    description:
+      '围绕 Blackwell GPU、TIRx、GEMM 与 Flash Attention 4 展开的现代 GPU 编程教程，点击后前往 MLC 官方中文版。',
+    statusLabel: '官方中文版 · 外部链接',
+    coverImage: '/images/columns/modern-gpu-programming-for-mlsys.svg',
+    coverAlt: '由 GPU 计算单元和数据流组成的抽象专栏封面',
+    coverWidth: 1200,
+    coverHeight: 675,
+    topics: ['Blackwell', 'TIRx', 'GEMM', 'Flash Attention 4'],
   },
 ] as const satisfies readonly ColumnDefinition[];
 

--- a/src/pages/scaling-book/[chapter].astro
+++ b/src/pages/scaling-book/[chapter].astro
@@ -144,9 +144,7 @@ const sourceUrl = `${SCALING_BOOK_REPOSITORY_URL}/blob/${chapter.data.sourceComm
     margin-inline: auto;
   }
 
-  :root.dark
-    [data-book-chapter]
-    img[src$='/mixed-fsdp-comms-2.png'] {
+  :root.dark [data-book-chapter] img[src$='/mixed-fsdp-comms-2.png'] {
     padding: 0.75rem;
     border: 1px solid rgb(63 63 70 / 0.9);
     background: white;

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -409,8 +409,16 @@ test.describe('Blog smoke journey', () => {
     const topButton = page.locator('[data-scroll-up-top-button]');
     await expect(topButton).toHaveAttribute('data-visible', 'false');
 
-    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
-    await page.waitForTimeout(200);
+    await page.evaluate(() => {
+      document.documentElement.style.scrollBehavior = 'auto';
+      window.scrollTo(0, document.documentElement.scrollHeight);
+    });
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        ),
+    );
     await expect(topButton).toHaveAttribute('data-visible', 'false');
 
     await page.evaluate(() => window.scrollBy(0, -200));
@@ -571,7 +579,20 @@ test.describe('Blog smoke journey', () => {
     await page.goto('columns/', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('[data-columns-index] h1')).toHaveText('专栏');
     await expect(page.locator('header nav a[aria-current="page"]')).toHaveText('Columns');
-    await expect(page.locator('[data-column-card]')).toHaveCount(1);
+    await expect(page.locator('[data-column-card]')).toHaveCount(2);
+    const modernGpuCard = page.locator('[data-column-slug="modern-gpu-programming-for-mlsys"]');
+    await expect(modernGpuCard).toContainText('面向机器学习系统的现代 GPU 编程');
+    const modernGpuLink = modernGpuCard.locator('a').first();
+    await expect(modernGpuLink).toHaveAttribute(
+      'href',
+      'https://mlc.ai/modern-gpu-programming-for-mlsys/zh/',
+    );
+    await expect(modernGpuLink).toHaveAttribute('target', '_blank');
+    await expect(modernGpuLink).toHaveAttribute('rel', 'noopener noreferrer');
+    const modernGpuCover = modernGpuCard.locator('img');
+    await expect
+      .poll(() => modernGpuCover.evaluate((image) => (image as HTMLImageElement).naturalWidth))
+      .toBeGreaterThan(0);
     const scalingBookCard = page.locator('[data-column-slug="scaling-book"]');
     await expect(scalingBookCard).toContainText('如何让模型高效扩展');
     const columnCover = scalingBookCard.locator('img');

--- a/tests/unit/columns.test.ts
+++ b/tests/unit/columns.test.ts
@@ -2,17 +2,22 @@ import { describe, expect, it } from 'vitest';
 import {
   COLUMN_CATALOG,
   COLUMNS_INDEX_PATH,
+  MODERN_GPU_PROGRAMMING_ZH_URL,
   findColumnBySlug,
 } from '../../src/lib/content/columns';
 
 describe('columns catalog', () => {
-  it('uses a dedicated index and unique internal routes', () => {
+  it('uses a dedicated index and unique routes', () => {
     expect(COLUMNS_INDEX_PATH).toBe('/columns/');
     expect(new Set(COLUMN_CATALOG.map((column) => column.slug)).size).toBe(COLUMN_CATALOG.length);
     expect(new Set(COLUMN_CATALOG.map((column) => column.href)).size).toBe(COLUMN_CATALOG.length);
 
     for (const column of COLUMN_CATALOG) {
-      expect(column.href).toMatch(/^\/[a-z0-9-]+\/$/);
+      if (column.isExternal) {
+        expect(column.href).toMatch(/^https:\/\//);
+      } else {
+        expect(column.href).toMatch(/^\/[a-z0-9-]+\/$/);
+      }
       expect(column.coverWidth).toBeGreaterThan(0);
       expect(column.coverHeight).toBeGreaterThan(0);
     }
@@ -23,6 +28,16 @@ describe('columns catalog', () => {
       expect.objectContaining({
         href: '/scaling-book/',
         shortTitle: 'Scaling Book 中文版',
+      }),
+    );
+  });
+
+  it('registers the official Modern GPU Programming Chinese edition as an external column', () => {
+    expect(findColumnBySlug('modern-gpu-programming-for-mlsys')).toEqual(
+      expect.objectContaining({
+        href: MODERN_GPU_PROGRAMMING_ZH_URL,
+        isExternal: true,
+        shortTitle: 'Modern GPU Programming For MLSys 中文版',
       }),
     );
   });

--- a/tests/unit/logger/logger.test.ts
+++ b/tests/unit/logger/logger.test.ts
@@ -7,12 +7,16 @@ import fs from 'fs';
 import { createLogger } from '../../../scripts/logger/logger';
 
 describe('Logger', () => {
+  const loggerEnvKeys = ['LOG_LEVEL', 'LOG_FORMAT', 'LOG_FILE', 'LOG_COLOR', 'LOG_SILENT'] as const;
   let originalEnv: NodeJS.ProcessEnv;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     originalEnv = { ...process.env };
+    for (const key of loggerEnvKeys) {
+      delete process.env[key];
+    }
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });


### PR DESCRIPTION
## What changed

- add the official Chinese edition of *Modern GPU Programming for MLSys* as an external blog column
- add a local original SVG cover and open the official site safely in a new tab
- include the requested “How to Scale Your Model” entry from `layout.yml`
- keep internal column routing and active navigation behavior unchanged

## CI fixes

- apply the pending Prettier formatting fix to the Scaling Book chapter template
- exclude raw Scaling Book Markdown from Lychee’s source-tree link resolution; its route-relative navigation and assets remain covered by build and E2E tests
- isolate logger tests from ambient `LOG_*` variables
- stabilize mobile header sizing and the scroll-to-top E2E timing

## Validation

- `npm run lint`
- `npm run depcruise:lint`
- 552 unit tests with coverage thresholds
- 22 Playwright scenarios passed, 1 existing conditional scenario skipped
- scroll-to-top scenario repeated 5 times successfully